### PR TITLE
Rabbitmq trigger

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
         run: sudo apt update && sudo apt install jo tox
       - id: setmatrix
         run: |
-          stringified_matrix=$(tox -a |grep -v -e venv -e format| jo -a)
+          stringified_matrix=$(tox -a |grep -v -e venv -e format -e trigger-tests| jo -a)
           echo "::set-output name=matrix::$stringified_matrix"
 
   test-containers:

--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -3,6 +3,7 @@ name: container security scan
 on:
   schedule:
     - cron: '0 0 * * *'
+  repository_dispatch:
 
 jobs:
   gentestmatrix:

--- a/matryoshka_tester/parse_data.py
+++ b/matryoshka_tester/parse_data.py
@@ -1,6 +1,7 @@
 import json
 import os
 from dataclasses import dataclass
+from typing import List
 
 
 DEFAULT_REGISTRY = "registry.opensuse.org"
@@ -29,7 +30,7 @@ class Container:
             self.url = f"{self.registry}/{self.repo}/{self.image}:{self.tag}"
 
 
-def build_containerlist(filename: str = DEFAULT_CONTAINERS):
+def build_containerlist(filename: str = DEFAULT_CONTAINERS) -> List[Container]:
     with open(filename, "r") as dataf:
         return json.load(dataf, object_hook=lambda d: Container(**d))
 

--- a/matryoshka_tester/trigger_test.py
+++ b/matryoshka_tester/trigger_test.py
@@ -1,0 +1,175 @@
+from dataclasses import dataclass, field
+import json
+from logging import getLogger
+from os import environ
+from typing import (
+    Dict,
+    Literal,
+    List,
+    Optional,
+    NoReturn,
+    Tuple,
+    TypedDict,
+    Union,
+)
+
+import pika
+import requests
+
+from matryoshka_tester.parse_data import containers, Container
+
+
+LOGGER = getLogger(__name__)
+GITHUB_API_BASEURL = "https://api.github.com"
+
+
+class PublishBodyBase(TypedDict):
+    #: name of the project which' publishing state changed
+    project: str
+    #: repository which' publishing state changed
+    repo: str
+
+
+class PacktrackBody(PublishBodyBase):
+    #: some id identifying something
+    payload: str
+
+
+class PublishStateBody(PublishBodyBase):
+    #: the new state of the project + repository
+    state: Literal[
+        "unknown",
+        "broken",
+        "scheduling",
+        "blocked",
+        "building",
+        "finished",
+        "publishing",
+        "published",
+        "unpublished",
+    ]
+
+
+class PublishedBody(PublishBodyBase):
+    #: some internal (=undocumented) build ID
+    buildid: str
+
+
+def trigger_workflow(
+    event_type: str = "containers_published",
+    owner: str = "SUSE",
+    repo: str = "m8a-tests",
+):
+    headers = {
+        "Accept": "application/vnd.github.v3+json",
+        "Authorization": f"token {environ['GITHUB_TOKEN']}",
+    }
+
+    try:
+        resp = requests.post(
+            f"{GITHUB_API_BASEURL}/repos/{owner}/{repo}/dispatches",
+            json={"event_type": event_type},
+            headers=headers,
+        )
+
+        if resp.status_code != 204:
+            LOGGER.error("triggering the workflow failed with %s", resp.status)
+    except Exception as exc:
+        LOGGER.error("sending the workflow trigger failed with %s", exc)
+
+
+@dataclass
+class RabbitMQConnection:
+    #: url to the message bus, defaults to openSUSE's
+    url: str = "amqps://opensuse:opensuse@rabbit.opensuse.org"
+    #: the rabbitMQ prefix used by OBS, see
+    #: https://openbuildservice.org/help/manuals/obs-admin-guide/obs.cha.administration.html#_message_bus
+    message_topic_prefix: str = "opensuse.obs"
+
+    #: list of routing keys corresponding to the repository publishing events
+    repository_routing_keys: List[str] = field(default_factory=list)
+
+    #: Dictionary of project names (as keys) mapping to a list of repositories
+    #: whose publishing event triggers a CI run on github
+    watched_projects: Dict[str, List[str]] = field(default_factory=dict)
+
+    container_list: Optional[List[Container]] = None
+
+    def __post_init__(self):
+        if self.container_list is None:
+            self.container_list = containers
+
+        self.repository_routing_keys = [
+            f"{self.message_topic_prefix}.repo.publish_state",
+            f"{self.message_topic_prefix}.repo.published",
+        ]
+
+        for container in self.container_list:
+            repo_entries = container.repo.split("/")
+            project = ":".join(repo_entries[:-1])
+            repository = repo_entries[-1]
+            if (
+                project in self.watched_projects
+                and repository not in self.watched_projects[project]
+            ):
+                self.watched_projects[project].append(repository)
+            elif project not in self.watched_projects:
+                self.watched_projects[project] = [repository]
+
+    def connect_channel_to_bus(self) -> Tuple[pika.channel.Channel, str]:
+        connection = pika.BlockingConnection(
+            pika.URLParameters("amqps://opensuse:opensuse@rabbit.opensuse.org")
+        )
+        channel = connection.channel()
+
+        channel.exchange_declare(
+            exchange="pubsub",
+            exchange_type="topic",
+            passive=True,
+            durable=True,
+        )
+
+        result = channel.queue_declare("", exclusive=True)
+        queue_name = result.method.queue
+
+        channel.queue_bind(
+            exchange="pubsub", queue=queue_name, routing_key="#"
+        )
+        return channel, queue_name
+
+    def get_callback(self):
+        def callback(ch, method, properties, body):
+            if method.routing_key in self.repository_routing_keys:
+                try:
+                    payload: Union[
+                        PublishStateBody, PublishedBody
+                    ] = json.loads(body)
+                except json.decoder.JSONDecodeError:
+                    return
+
+                if (
+                    payload is None
+                    or payload["project"] not in self.watched_projects
+                ):
+                    return
+
+                if (
+                    payload["repo"]
+                    in self.watched_projects[payload["project"]]
+                ):
+                    trigger_workflow()
+
+        return callback
+
+
+def trigger_from_mqtt(connection: RabbitMQConnection() = None) -> NoReturn:
+    if not environ.get("GITHUB_TOKEN"):
+        raise RuntimeError("environment variable GITHUB_TOKEN not set")
+
+    if connection is None:
+        connection = RabbitMQConnection()
+
+    channel, queue_name = connection.connect_channel_to_bus()
+
+    channel.basic_consume(queue_name, connection.get_callback(), auto_ack=True)
+    channel.start_consuming()

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,4 @@ console_scripts =
     m8s-list-containers = matryoshka_tester.cmds:list_containers
     m8a-fetch-all-containers = matryoshka_tester.cmds:fetch_all_containers
     m8a-fetch-language-containers = matryoshka_tester.cmds:fetch_language_containers
+    m8a-trigger-tests-from-mqtt = matryoshka_tester.trigger_test:trigger_from_mqtt

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,10 @@ deps =
     pytest-xdist[psutil]
     pytest-custom_exit_code
     prettytable
+    # we want to keep these in the main one as they will be otherwise not in the
+    # venv environment
+    pika
+    requests
 allowlist_externals =
     docker
     podman
@@ -42,6 +46,11 @@ deps =
     black
 commands =
     black . matryoshka_tester []
+
+[testenv:trigger-tests]
+commands =
+    m8a-trigger-tests-from-mqtt
+passenv = GITHUB_TOKEN
 
 [testenv:venv]
 passenv = *


### PR DESCRIPTION
This PR is based on #39: it adds a new entry point that listens to rabbit.opensuse.org and launches the CI pipeline every time the repositories get published.