### PR TITLE
Fix and simplify CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
         run: sudo apt update && sudo apt install jo tox
       - id: setmatrix
         run: |
-          stringified_matrix=$(tox -a |grep -v -e venv -e format -e trigger-tests| jo -a)
+          stringified_matrix=$(tox -l| jo -a)
           echo "::set-output name=matrix::$stringified_matrix"
 
   test-containers:

--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -18,7 +18,7 @@ jobs:
         run: sudo apt update && sudo apt install jo tox
       - id: setmatrix
         run: |
-          stringified_matrix=$(tox -q -e list-all | sed '/^|/!d; /Language/d' | awk -F"|" '{print $4}'| sed 's/^[ \t]*//;s/[ \t]*$//' | jo -a)
+          stringified_matrix=$(tox -q -e list-all | awk  '/\|.*\|.*\|.*\|(.*)/ {print $8;}' | grep -v 'URL' | jo -a)
           echo "::set-output name=matrix::$stringified_matrix"
 
   snyk:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = unit, base, python, node, go, openjdk, openjdk-devel, multistage
+envlist = unit, base, python, node, go, openjdk, openjdk-devel, multistage, fetch-all, list-all
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
Without this, the container-scan is incorrectly having the version
instead of the URL to test.

This is a problem, as it will prevent those tests to run correctly.

This fixes it by simplifying the stringified_matrix generation,
adapting to the right filed.

Next to this, the ci is using tox, but we have established a list
of what we test inside the CI that's not matching tox, for
simplicity.

Because we are having more and more tests, I simplified so that
the CI is matching tox envlist. Extra environments won't be
tested, as it is done currently.
