### PR TITLE
Ensure base images don't contain grep

### DIFF
--- a/test_base.py
+++ b/test_base.py
@@ -22,6 +22,10 @@ def test_base_size(container, container_runtime):
     )
 
 
+def test_grep_absent(container):
+    assert not container.connection.exists("grep")
+
+
 # FIPS tests
 with_fips = pytest.mark.skipif(
     not host_fips_enabled(), reason="host not running in FIPS 140 mode"


### PR DESCRIPTION
Because of size for minimum runtime containers, we want to
remove as much as possible from base.
