### PR TITLE
Add a way to test decompressed size of containers

### DIFF
--- a/matryoshka_tester/helpers.py
+++ b/matryoshka_tester/helpers.py
@@ -43,6 +43,15 @@ class OciRuntimeBase(ABC, ToParamMixin):
     def get_image_id_from_stdout(self, stdout: str) -> str:
         pass
 
+    def get_image_size(self, image: str) -> float:
+        cmd = LOCALHOST.run_expect(
+            [0],
+            f"{self.runner_binary} inspect -f "
+            + '"{{ .Size }}"'
+            + f" {image}",
+        )
+        return float(cmd.stdout)
+
     def __str__(self) -> str:
         return self.__class__.__name__
 

--- a/test_base.py
+++ b/test_base.py
@@ -1,15 +1,25 @@
 import pytest
 from matryoshka_tester.fips import (
     host_fips_enabled,
-    host_fips_supported,
     NONFIPS_DIGESTS,
     FIPS_DIGESTS,
     ALL_DIGESTS,
 )
 
+#: 100MB limit for the base container
+BASE_CONTAINER_MAX_SIZE = 100 * 1024 * 1024
+
+
 # Generic tests
 def test_passwd_present(container):
     assert container.connection.file("/etc/passwd").exists
+
+
+def test_base_size(container, container_runtime):
+    assert (
+        container_runtime.get_image_size(container.image)
+        < BASE_CONTAINER_MAX_SIZE
+    )
 
 
 # FIPS tests

--- a/test_go.py
+++ b/test_go.py
@@ -5,6 +5,16 @@ import pytest
 from matryoshka_tester.helpers import GitRepositoryBuild
 
 
+GOLANG_MAX_CONTAINER_SIZE_ON_DISK = 1181116006  # 1.1GB uncompressed
+
+
+def test_go_size(host, container, container_runtime):
+    assert (
+        container_runtime.get_image_size(container.image)
+        < GOLANG_MAX_CONTAINER_SIZE_ON_DISK
+    )
+
+
 def test_go_version(container):
     assert container.version in container.connection.check_output("go version")
 


### PR DESCRIPTION
Without this, we don't ensure any size of containers.
This is a first step, tackling the decompressed size,
until we have other tests to tackle the compressed
size present in the registry.
