### PR TITLE
Add check that systemd is not present in non-init containers

### DIFF
--- a/test_init.py
+++ b/test_init.py
@@ -40,3 +40,10 @@ def test_docker_in_docker(container):
         "docker run --rm registry.opensuse.org/opensuse/tumbleweed:latest "
         "/usr/bin/ls",
     )
+
+
+@pytest.mark.parametrize(
+    "container", [c for c in containers if c.type != "init"], indirect=True
+)
+def test_systemd_not_installed_elsewhere(container):
+    assert not container.connection.package("systemd").is_installed


### PR DESCRIPTION
This fixes https://github.com/SUSE/BCI-tests/issues/69