### PR TITLE
import Literal from typing_extensions for python 3.6

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -1,8 +1,14 @@
 import os
 from typing import List
-from typing import Literal
 from typing import Optional
 from typing import Sequence
+
+try:
+    from typing import Literal
+except ImportError:
+    # typing.Literal is available on python3.8+
+    # https://docs.python.org/3/library/typing.html#typing.Literal
+    from typing_extensions import Literal
 
 import pytest
 from _pytest.mark.structures import MarkDecorator

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
     pytest-xdist ; python_version >= "3.6"
     dataclasses ; python_version < "3.7"
     pytest-rerunfailures
+    typing_extensions
     git+https://github.com/dcermak/pytest_container
     doc: Sphinx
 allowlist_externals =


### PR DESCRIPTION
`typing.Literal` is available after python3.8, and openQA
tests with "old" hosts are using python3.6.