### PR TITLE
Add BUSYBOX_CONTAINER to CONTAINERS_WITHOUT_ZYPPER

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -370,6 +370,7 @@ CONTAINERS_WITH_ZYPPER = [
 CONTAINERS_WITHOUT_ZYPPER = [
     MINIMAL_CONTAINER,
     MICRO_CONTAINER,
+    BUSYBOX_CONTAINER,
 ]
 
 #: Containers that are directly pulled from registry.suse.de

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -8,6 +8,7 @@ from pytest_container import get_extra_run_args
 from pytest_container import MultiStageBuild
 
 from bci_tester.data import ALL_CONTAINERS
+from bci_tester.data import BUSYBOX_CONTAINER
 from bci_tester.data import GO_1_16_CONTAINER
 from bci_tester.data import INIT_CONTAINER
 from bci_tester.data import OS_PRETTY_NAME
@@ -77,13 +78,18 @@ def test_product(auto_container):
     )
 
 
-def test_coreutils_present(auto_container):
+@pytest.mark.parametrize(
+    "container",
+    [c for c in ALL_CONTAINERS if c != BUSYBOX_CONTAINER],
+    indirect=True,
+)
+def test_coreutils_present(container):
     """
     Check that some core utilities (:command:`cat`, :command:`sh`, etc.) exist
     in the container.
     """
     for binary in ("cat", "sh", "bash", "ls", "rm"):
-        assert auto_container.connection.exists(binary)
+        assert container.connection.exists(binary)
 
 
 def test_glibc_present(auto_container):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -28,6 +28,7 @@ from pytest_container.runtime import LOCALHOST
 
 from bci_tester.data import ALL_CONTAINERS
 from bci_tester.data import BASE_CONTAINER
+from bci_tester.data import BUSYBOX_CONTAINER
 from bci_tester.data import CONTAINER_389DS
 from bci_tester.data import DOTNET_ASPNET_3_1_CONTAINER
 from bci_tester.data import DOTNET_ASPNET_5_0_CONTAINER
@@ -87,6 +88,7 @@ IMAGES_AND_NAMES: List[ParameterSet] = [
         (BASE_CONTAINER, "base", ImageType.OS),
         (MINIMAL_CONTAINER, "minimal", ImageType.OS),
         (MICRO_CONTAINER, "micro", ImageType.OS),
+        (BUSYBOX_CONTAINER, "busybox", ImageType.OS),
         (GO_1_16_CONTAINER, "golang", ImageType.LANGUAGE_STACK),
         (GO_1_17_CONTAINER, "golang", ImageType.LANGUAGE_STACK),
         (GO_1_18_CONTAINER, "golang", ImageType.LANGUAGE_STACK),

--- a/tests/test_minimal.py
+++ b/tests/test_minimal.py
@@ -3,12 +3,9 @@ from typing import Dict
 import pytest
 from pytest_container.runtime import LOCALHOST
 
-from bci_tester.data import CONTAINERS_WITHOUT_ZYPPER
 from bci_tester.data import MICRO_CONTAINER
 from bci_tester.data import MINIMAL_CONTAINER
 
-
-CONTAINER_IMAGES = CONTAINERS_WITHOUT_ZYPPER
 
 #: size limits of the minimal image per architecture in MiB
 MINIMAL_IMAGE_MAX_SIZE: Dict[str, int] = {
@@ -54,7 +51,10 @@ def test_minimal_image_size(
     )
 
 
-def test_fat_packages_absent(auto_container):
+@pytest.mark.parametrize(
+    "container", [MICRO_CONTAINER, MINIMAL_CONTAINER], indirect=True
+)
+def test_fat_packages_absent(container):
     """Verify that the following binaries do not exist:
     - :command:`zypper`
     - :command:`grep`
@@ -64,7 +64,7 @@ def test_fat_packages_absent(auto_container):
     - :command:`man`
     """
     for pkg in ("zypper", "grep", "diff", "sed", "info", "man"):
-        assert not auto_container.connection.exists(pkg)
+        assert not container.connection.exists(pkg)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Reason: `tox -e all -- -n auto -k bci/bci-busybox_15.4` fails with no test runs.