### PR TITLE
Remove xfail in minimal image size check

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -10,6 +10,8 @@ from pytest_container import auto_container_parametrize
 from pytest_container import get_selected_runtime
 from pytest_container import GitRepositoryBuild
 from pytest_container.helpers import add_extra_run_and_build_args_options
+from pytest_container.helpers import add_logging_level_options
+from pytest_container.helpers import set_logging_level_from_cli_args
 
 
 @pytest.fixture(scope="function")
@@ -96,6 +98,11 @@ def pytest_generate_tests(metafunc):
 
 def pytest_addoption(parser):
     add_extra_run_and_build_args_options(parser)
+    add_logging_level_options(parser)
+
+
+def pytest_configure(config):
+    set_logging_level_from_cli_args(config)
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_minimal.py
+++ b/tests/test_minimal.py
@@ -9,10 +9,10 @@ from bci_tester.data import MINIMAL_CONTAINER
 
 #: size limits of the minimal image per architecture in MiB
 MINIMAL_IMAGE_MAX_SIZE: Dict[str, int] = {
-    "x86_64": 40,
-    "aarch64": 44,
-    "s390x": 40,
-    "ppc64le": 51,
+    "x86_64": 46,
+    "aarch64": 49,
+    "s390x": 46,
+    "ppc64le": 57,
 }
 #: size limits of the micro image per architecture in MiB
 MICRO_IMAGE_MAX_SIZE: Dict[str, int] = {
@@ -26,13 +26,7 @@ MICRO_IMAGE_MAX_SIZE: Dict[str, int] = {
 @pytest.mark.parametrize(
     "container,size",
     [
-        pytest.param(
-            MINIMAL_CONTAINER,
-            MINIMAL_IMAGE_MAX_SIZE,
-            marks=pytest.mark.xfail(
-                reason="Temporary size increase due to mozilla cert bundle hack"
-            ),
-        ),
+        (MINIMAL_CONTAINER, MINIMAL_IMAGE_MAX_SIZE),
         (MICRO_CONTAINER, MICRO_IMAGE_MAX_SIZE),
     ],
     indirect=["container"],


### PR DESCRIPTION
Currently we are completely blind to the size increases as the minimal image size check has been gated by an xfail.