### PR TITLE
Add pcp tests

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -311,7 +311,8 @@ INIT_CONTAINER = create_BCI(
 PCP_CONTAINER = create_BCI(
     build_tag=f"suse/pcp:5.2.2",
     image_type="dockerfile",
-    available_versions=["15.3"],
+    singleton=True,
+    extra_marks=[pytest.mark.skipif(DOCKER_SELECTED, reason="only podman is supported")],
     extra_launch_args=[]
     if DOCKER_SELECTED
     else [

--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -308,6 +308,21 @@ INIT_CONTAINER = create_BCI(
     default_entry_point=True,
 )
 
+PCP_CONTAINER = create_BCI(
+    build_tag=f"suse/pcp:5.2.2",
+    image_type="dockerfile",
+    available_versions=["15.3"],
+    extra_launch_args=[]
+    if DOCKER_SELECTED
+    else [
+        "--systemd",
+        "always",
+        "-p",
+        "44322:44322",
+    ],
+    default_entry_point=True,
+)
+
 CONTAINER_389DS = create_BCI(
     build_tag="suse/389-ds:2.0",
     image_type="dockerfile",
@@ -358,6 +373,7 @@ CONTAINERS_WITH_ZYPPER = [
     NODEJS_12_CONTAINER,
     NODEJS_14_CONTAINER,
     NODEJS_16_CONTAINER,
+    PCP_CONTAINER,
     PYTHON36_CONTAINER,
     PYTHON39_CONTAINER,
     PYTHON310_CONTAINER,

--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -312,7 +312,9 @@ PCP_CONTAINER = create_BCI(
     build_tag=f"suse/pcp:5.2.2",
     image_type="dockerfile",
     singleton=True,
-    extra_marks=[pytest.mark.skipif(DOCKER_SELECTED, reason="only podman is supported")],
+    extra_marks=[
+        pytest.mark.skipif(DOCKER_SELECTED, reason="only podman is supported")
+    ],
     extra_launch_args=[]
     if DOCKER_SELECTED
     else [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,8 @@ markers = [
     'bci/dotnet-aspnet_3.1',
     'bci/dotnet-aspnet_5.0',
     'bci/dotnet-aspnet_6.0',
-    'suse/389-ds_2.0'
+    'suse/389-ds_2.0',
+    'suse/pcp_5.2.2'
 ]
 
 [tool.black]

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -54,6 +54,7 @@ from bci_tester.data import OPENJDK_DEVEL_11_CONTAINER
 from bci_tester.data import OPENJDK_DEVEL_17_CONTAINER
 from bci_tester.data import OS_SP_VERSION
 from bci_tester.data import OS_VERSION
+from bci_tester.data import PCP_CONTAINER
 from bci_tester.data import PYTHON310_CONTAINER
 from bci_tester.data import PYTHON36_CONTAINER
 from bci_tester.data import PYTHON39_CONTAINER
@@ -112,6 +113,7 @@ IMAGES_AND_NAMES: List[ParameterSet] = [
         (PYTHON310_CONTAINER, "python", ImageType.LANGUAGE_STACK),
         (RUBY_25_CONTAINER, "ruby", ImageType.LANGUAGE_STACK),
         (INIT_CONTAINER, "init", ImageType.OS),
+        (PCP_CONTAINER, "pcp", ImageType.APPLICATION),
         (CONTAINER_389DS, "389-ds", ImageType.APPLICATION),
         (DOTNET_SDK_3_1_CONTAINER, "dotnet.sdk", ImageType.LANGUAGE_STACK),
         (DOTNET_SDK_5_0_CONTAINER, "dotnet.sdk", ImageType.LANGUAGE_STACK),

--- a/tests/test_pcp.py
+++ b/tests/test_pcp.py
@@ -47,7 +47,7 @@ def test_call_pmproxy(auto_container_per_test):
 def wait_for_pmcd(con):
     """pmcd takes a little time to initialize things before it is ready"""
 
-    for _ in range(30):
+    for _ in range(60):
         rc = con.connection.run("systemctl is-active pmcd").rc
         if rc == 0:
             return

--- a/tests/test_pcp.py
+++ b/tests/test_pcp.py
@@ -2,29 +2,26 @@
 """
 import time
 
-import pytest
 from pytest_container.runtime import LOCALHOST
 
 from bci_tester.data import PCP_CONTAINER
-from bci_tester.runtime_choice import DOCKER_SELECTED
 
+CONTAINER_IMAGES = [PCP_CONTAINER]
 
-@pytest.mark.parametrize("container", [PCP_CONTAINER], indirect=True)
-@pytest.mark.skipif(DOCKER_SELECTED, reason="only podman is supported")
-def test_systemd_present(container):
+def test_systemd_present(auto_container_per_test):
     """Check that the pcp daemons are running."""
 
     # pcp needs a little time to initialize
     time.sleep(5)
 
-    assert container.connection.run_expect([0], "systemctl status")
-    assert container.connection.run_expect([0], "systemctl status pmcd")
-    assert container.connection.run_expect([0], "systemctl status pmlogger")
-    assert container.connection.run_expect([0], "systemctl status pmproxy")
-    assert container.connection.run_expect([0], "systemctl status pmie")
+    auto_container_per_test.connection.run_expect([0], "systemctl status")
+    auto_container_per_test.connection.run_expect([0], "systemctl status pmcd")
+    auto_container_per_test.connection.run_expect([0], "systemctl status pmlogger")
+    auto_container_per_test.connection.run_expect([0], "systemctl status pmproxy")
+    auto_container_per_test.connection.run_expect([0], "systemctl status pmie")
 
     # test call to pmcd
-    assert container.connection.run_expect([0], "pmprobe -v mem.physmem")
+    auto_container_per_test.connection.run_expect([0], "pmprobe -v mem.physmem")
 
     # test call to pmproxy
     if LOCALHOST.exists("curl"):

--- a/tests/test_pcp.py
+++ b/tests/test_pcp.py
@@ -48,7 +48,7 @@ def wait_for_pmcd(con):
     """pmcd takes a little time to initialize things before it is ready"""
 
     for _ in range(30):
-        rc = con.connection.run("systemctl status pmcd").rc
+        rc = con.connection.run("systemctl is-active pmcd").rc
         if rc == 0:
             return
         time.sleep(1)

--- a/tests/test_pcp.py
+++ b/tests/test_pcp.py
@@ -1,0 +1,34 @@
+"""This module contains the tests for the pcp container
+"""
+import time
+
+import pytest
+from pytest_container.runtime import LOCALHOST
+
+from bci_tester.data import PCP_CONTAINER
+from bci_tester.runtime_choice import DOCKER_SELECTED
+
+
+@pytest.mark.parametrize("container", [PCP_CONTAINER], indirect=True)
+@pytest.mark.skipif(DOCKER_SELECTED, reason="only podman is supported")
+def test_systemd_present(container):
+    """Check that the pcp daemons are running."""
+
+    # pcp needs a little time to initialize
+    time.sleep(5)
+
+    assert container.connection.run_expect([0], "systemctl status")
+    assert container.connection.run_expect([0], "systemctl status pmcd")
+    assert container.connection.run_expect([0], "systemctl status pmlogger")
+    assert container.connection.run_expect([0], "systemctl status pmproxy")
+    assert container.connection.run_expect([0], "systemctl status pmie")
+
+    # test call to pmcd
+    assert container.connection.run_expect([0], "pmprobe -v mem.physmem")
+
+    # test call to pmproxy
+    if LOCALHOST.exists("curl"):
+        assert LOCALHOST.run_expect(
+            [0],
+            "curl -s http://localhost:44322/metrics?names=mem.physmem",
+        )

--- a/tests/test_pcp.py
+++ b/tests/test_pcp.py
@@ -9,21 +9,34 @@ from bci_tester.data import PCP_CONTAINER
 CONTAINER_IMAGES = [PCP_CONTAINER]
 
 
-def test_systemd_present(auto_container_per_test):
-    """Check that the pcp daemons are running."""
+def test_systemd_status(auto_container_per_test):
+    auto_container_per_test.connection.run_expect([0], "systemctl status")
+
+
+def test_pcp_services_status(auto_container_per_test):
+    """Check that the pcp services are healthy."""
 
     wait_for_pmcd(auto_container_per_test)
 
-    auto_container_per_test.connection.run_expect([0], "systemctl status")
     auto_container_per_test.connection.run_expect([0], "systemctl status pmcd")
-    auto_container_per_test.connection.run_expect([0], "systemctl status pmlogger")
-    auto_container_per_test.connection.run_expect([0], "systemctl status pmproxy")
+    auto_container_per_test.connection.run_expect(
+        [0], "systemctl status pmlogger"
+    )
+    auto_container_per_test.connection.run_expect(
+        [0], "systemctl status pmproxy"
+    )
     auto_container_per_test.connection.run_expect([0], "systemctl status pmie")
 
-    # test call to pmcd
-    auto_container_per_test.connection.run_expect([0], "pmprobe -v mem.physmem")
 
-    # test call to pmproxy
+def test_call_pmcd(auto_container_per_test):
+    wait_for_pmcd(auto_container_per_test)
+    auto_container_per_test.connection.run_expect(
+        [0], "pmprobe -v mem.physmem"
+    )
+
+
+def test_call_pmproxy(auto_container_per_test):
+    wait_for_pmcd(auto_container_per_test)
     if LOCALHOST.exists("curl"):
         assert LOCALHOST.run_expect(
             [0],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py36,py37,py38,py39,py310}-unit, build, all, base, init, dotnet, python, ruby, node, go, openjdk, openjdk_devel, busybox, 389ds, metadata, minimal, multistage, repository, doc, lint, get_urls
+envlist = {py36,py37,py38,py39,py310}-unit, build, all, base, init, dotnet, python, ruby, node, go, openjdk, openjdk_devel, busybox, 389ds, metadata, minimal, multistage, repository, doc, lint, get_urls, pcp
 isolated_build = True
 skip_missing_interpreters = True
 


### PR DESCRIPTION
This follows the init tests, as the pcp container is based on the
init container. The docker test is removed as only podman is supported.

WIP
export TARGET=x
export BASEURL=registry.suse.de/home/doreilly/branches/suse/sle-15-sp4/update/bci
tox -e pcp