### PR TITLE
Architecture not x86 skip tensorflow test

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -2,6 +2,7 @@
 import pytest
 from pytest_container import DerivedContainer
 from pytest_container.container import container_from_pytest_param
+from pytest_container.runtime import LOCALHOST
 
 from bci_tester.data import PYTHON310_CONTAINER
 from bci_tester.data import PYTHON36_CONTAINER
@@ -166,7 +167,11 @@ def test_python_webserver_2(container_per_test, host, container_runtime):
     # check expected file present in the bci destination
     assert container_per_test.connection.file(destdir + xfilename).exists
 
-
+@pytest.mark.skipif(
+    # skip test if architecture is not x86. 
+    LOCALHOST.system_info.arch != "x86_64",
+    reason="Tensorflow python library tested on x86_64",
+)
 @pytest.mark.parametrize(
     "container_per_test", CONTAINER_IMAGES_T, indirect=["container_per_test"]
 )


### PR DESCRIPTION
The test https://openqa.suse.de/tests/8754641 for aarch64 architecture passed all python tests, but not that on Tensorflow, because a ready to work library is actually not available for architectures other than x86-64, so in such cases this test will be skipped.