### PR TITLE
Increase to 80s healthy check timeout for 389ds container

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -309,7 +309,7 @@ CONTAINER_389DS = create_BCI(
     image_type="dockerfile",
     available_versions=["15.4"],
     default_entry_point=True,
-    healthcheck_timeout_ms=60 * 1000,
+    healthcheck_timeout_ms=80 * 1000,
     extra_launch_args=["-p", "3389:3389"],
     extra_environment_variables={"SUFFIX_NAME": "dc=example,dc=com"},
     singleton=True,


### PR DESCRIPTION
Looks like https://github.com/SUSE/BCI-tests/pull/121 was not enough. There are random timeouts (but less frequent than before). After looking at the failed tests, I think 80s is safer.
e.g. https://openqa.suse.de/tests/8788126#step/all/5