### PR TITLE
Bugfix init container: restore default_entry_point=True

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -292,6 +292,7 @@ INIT_CONTAINER = create_BCI(
     build_tag=f"bci/bci-init:{OS_VERSION}",
     image_type="hybrid",
     available_versions=[OS_VERSION],
+    default_entry_point=True,
     extra_marks=[
         pytest.mark.skipif(
             DOCKER_SELECTED,


### PR DESCRIPTION
It was removed by accident in https://github.com/SUSE/BCI-tests/pull/130