### PR TITLE
Bci python webserver_1 fix for podman old version

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -131,7 +131,7 @@ def test_python_webserver_1(
 
         # container version: old versions have issues with background processes
         if int(podman_version[0]) < 2:
-            pytest.xfail(
+            pytest.skip(
                 "server port checks not compatible with old podman versions 1"
             )
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -18,8 +18,6 @@ appl1 = "tensorflow_examples.py"
 port1 = 8123
 t0 = time.time()
 
-#container_version = lambda container_runtime: re.sub("[^0-9.:_-]", "", LOCALHOST.run(container_runtime.runner_binary + " --version")
-
 # copy tensorflow module trainer from the local application directory to the container
 DOCKERF_PY_T1 = f"""
 WORKDIR {bcdir}
@@ -71,7 +69,12 @@ CONTAINER_IMAGES_T2 = [
 ]
 
 # get container version and clean the result from not (numeric or separators) chars.
-container_version = lambda container_runtime: re.sub("[^0-9.,:_-]", "", LOCALHOST.run(container_runtime.runner_binary + " --version").stdout)
+container_version = lambda container_runtime: re.sub(
+    "[^0-9.,:_-]",
+    "",
+    LOCALHOST.run(container_runtime.runner_binary + " --version").stdout,
+)
+
 
 def test_python_version(auto_container):
     """Test that the python version equals the value from the environment variable
@@ -128,7 +131,9 @@ def test_python_webserver_1(
 
         # container version: old versions have issues with background processes
         if int(podman_version[0]) < 2:
-            pytest.xfail("server port checks not compatible with old podman versions 1")
+            pytest.xfail(
+                "server port checks not compatible with old podman versions 1"
+            )
 
     command = f"timeout --preserve-status 120 python3 -m {hmodule} {port} &"
 
@@ -154,7 +159,7 @@ def test_python_webserver_1(
         portstatus = container_per_test.connection.socket(
             f"tcp://0.0.0.0:{port}"
         ).is_listening
-        
+
         if portstatus:
             break
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1,15 +1,17 @@
 """Basic tests for the Python base container images."""
-import pytest
 import re
 import time
 
+import pytest
 from bci_tester.data import PYTHON310_CONTAINER
 from bci_tester.data import PYTHON36_CONTAINER
 from bci_tester.data import PYTHON39_CONTAINER
 from bci_tester.runtime_choice import PODMAN_SELECTED
-from pytest_container import DerivedContainer, OciRuntimeBase
+from pytest_container import DerivedContainer
+from pytest_container import OciRuntimeBase
 from pytest_container.container import container_from_pytest_param
-from pytest_container.runtime import LOCALHOST, get_selected_runtime
+from pytest_container.runtime import get_selected_runtime
+from pytest_container.runtime import LOCALHOST
 
 bcdir = "/tmp/"
 orig = "tests/"


### PR DESCRIPTION
an Issue was found in the test_python - test_webserver_1 that was related to the hdd_1 qcow2 having an old podman version 1.x.x.
Here the VR:
http://marvin5.arch.suse.cz/tests/229  # sles es 8.5, regression podman.v.4x: `PASS`
http://marvin5.arch.suse.cz/tests/228  # sles es 7.9, fix podman.v.1x: `PASS`!
