### PR TITLE
Fix the test matrix generation: exclude lint & doc

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
         run: sudo apt update && sudo apt install jo tox
       - id: setmatrix
         run: |
-          stringified_matrix=$(tox -l | sed -e '/unit/d' -e '/get_urls/d'|jo -a)
+          stringified_matrix=$(tox -l | sed -e '/unit/d' -e '/get_urls/d' -e '/doc/d' -e '/lint/d' | jo -a)
           echo "::set-output name=matrix::$stringified_matrix"
 
   unit-tests:


### PR DESCRIPTION
The lint & doc tox targets were accidentally included in the test matrix and
created for each container runtime and each OS version, which makes no sense at
all. The sed call in the test matrix generation simply needs adjusting to
exclude these two environments that are run separately already.