### PR TITLE
Remove pointless env var TOX_PARALLEL_NO_SPINNER from ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,9 +8,6 @@ on:
   pull_request:
   repository_dispatch:
 
-env:
-  TOX_PARALLEL_NO_SPINNER: 1
-
 jobs:
   format:
     name: Ensure code is black formatted


### PR DESCRIPTION
This environment variable is only useful when running `tox --parallel`, which we don't.