### PR TITLE
Increase boottimes for init container

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -34,9 +34,9 @@ class TestSystemd:
     def test_systemd_boottime(self, auto_container):
         """Ensure the container startup time is below 5 seconds"""
 
-        STARTUP_LIMIT = 5  # Container startup time limit in seconds
+        STARTUP_LIMIT = 5.5  # Container startup time limit in seconds
         TARGET_LIMIT = (
-            5  # Limit for the systemd target to be reached in seconds
+            5.5  # Limit for the systemd target to be reached in seconds
         )
 
         def extract_time(stdout, prefix):


### PR DESCRIPTION
It fails sometimes in ARM: https://openqa.suse.de/tests/9048340#step/init/1
Verification run with 5.5s: https://openqa.suse.de/tests/9057206
