### PR TITLE
Increase max size for BCI base for aarch64 and ppc64le

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -21,8 +21,8 @@ from bci_tester.runtime_choice import DOCKER_SELECTED
 #: size limits of the base container per arch in MiB
 BASE_CONTAINER_MAX_SIZE: Dict[str, int] = {
     "x86_64": 120,
-    "aarch64": 130,
-    "ppc64le": 150,
+    "aarch64": 135,
+    "ppc64le": 160,
     "s390x": 120,
 }
 


### PR DESCRIPTION
After trying to enable bci tests for base image, I found the following errors:
aarch64:
```
>       assert (
            container_runtime.get_image_size(auto_container.image_url_or_id)
            < BASE_CONTAINER_MAX_SIZE[LOCALHOST.system_info.arch] * 1024 * 1024
        )
E       AssertionError: assert 137972672.0 < ((130 * 1024) * 1024)
```

s390x:
```
>       assert (
            container_runtime.get_image_size(auto_container.image_url_or_id)
            < BASE_CONTAINER_MAX_SIZE[LOCALHOST.system_info.arch] * 1024 * 1024
        )
E       AssertionError: assert 160373180.0 < ((150 * 1024) * 1024)
```