### PR TITLE
Run openssl gost output less strict

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -82,10 +82,10 @@ def test_openssl_hashes(auto_container):
         auto_container.connection.run_expect([0], f"openssl {md} /dev/null")
 
     assert (
-        auto_container.connection.run_expect(
+        "gost is not a known digest"
+        in auto_container.connection.run_expect(
             [1], "openssl gost /dev/null"
         ).stderr.strip()
-        == "gost is not a known digest"
     )
 
 


### PR DESCRIPTION
With old podman versions, the output of `openssl gost` command is:
```
podman exec 9e /bin/sh -c 'openssl gost /dev/null'
gost is not a known digest
Error: non zero exit code: 1: OCI runtime error
```
instead of just
```
podman exec 9e /bin/sh -c 'openssl gost /dev/null'
gost is not a known digest
```
with newer podman versions.

So, it contains some additional text, and the assertion fails
because we are only expecting "gost is not a known digest".
By doing it as I'm proposing, we cover both cases.