### PR TITLE
Increase Base Image max size to 125 for s390x

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -23,7 +23,7 @@ BASE_CONTAINER_MAX_SIZE: Dict[str, int] = {
     "x86_64": 120,
     "aarch64": 135,
     "ppc64le": 160,
-    "s390x": 120,
+    "s390x": 125,
 }
 
 CONTAINER_IMAGES = [BASE_CONTAINER]


### PR DESCRIPTION
Error on s390x:
```
>       assert (
            container_runtime.get_image_size(auto_container.image_url_or_id)
            < BASE_CONTAINER_MAX_SIZE[LOCALHOST.system_info.arch] * 1024 * 1024
        )
E       AssertionError: assert 128462272.0 < ((120 * 1024) * 1024)
```
e.g. https://openqa.suse.de/tests/9188890#step/base/1

VR: http://openqa.suse.de/t9197006
