### PR TITLE
Increase Base Image max size to 140 for aarch64

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -21,7 +21,7 @@ from bci_tester.runtime_choice import DOCKER_SELECTED
 #: size limits of the base container per arch in MiB
 BASE_CONTAINER_MAX_SIZE: Dict[str, int] = {
     "x86_64": 120,
-    "aarch64": 135,
+    "aarch64": 140,
     "ppc64le": 160,
     "s390x": 125,
 }


### PR DESCRIPTION
error: https://openqa.suse.de/tests/9196759#step/base/1
```
>       assert (
            container_runtime.get_image_size(auto_container.image_url_or_id)
            < BASE_CONTAINER_MAX_SIZE[LOCALHOST.system_info.arch] * 1024 * 1024
        )
E       AssertionError: assert 141679558.0 < ((135 * 1024) * 1024)
```
VR: http://openqa.suse.de/t9197854