### PR TITLE
Install dapper via download for go < 1.17 and don't build rancher on ppc64

### DIFF
--- a/bci_tester/util.py
+++ b/bci_tester/util.py
@@ -4,6 +4,19 @@ from dataclasses import dataclass
 from typing import Dict
 from typing import List
 
+from pytest_container import Version
+
+
+def get_host_go_version(host) -> Version:
+    # output of go version:
+    # go version go1.19.1 linux/amd64
+    return Version.parse(
+        host.run_expect([0], "go version")
+        .stdout.strip()
+        .split()[2]
+        .replace("go", "")
+    )
+
 
 @dataclass(frozen=True)
 class Repository:

--- a/tests/test_go.py
+++ b/tests/test_go.py
@@ -5,6 +5,7 @@ import pytest
 from pytest_container import GitRepositoryBuild
 from pytest_container import Version
 from pytest_container.container import ContainerData
+from pytest_container.runtime import LOCALHOST
 
 from bci_tester.data import BASE_CONTAINER
 from bci_tester.data import GO_1_16_CONTAINER
@@ -146,6 +147,10 @@ def test_build_generics_cache(
 )
 @pytest.mark.skipif(
     not DOCKER_SELECTED, reason="Dapper only works with docker"
+)
+@pytest.mark.skipif(
+    LOCALHOST.system_info.arch not in ("x86_64", "aarch64", "s390x"),
+    reason=f"{LOCALHOST.system_info.arch} is not supported to build rancher",
 )
 def test_rancher_build(
     host, host_git_clone, dapper, container: ContainerData, go_version: Version


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/117373