### PR TITLE
Remove chalk repo from npm tests

### DIFF
--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -39,10 +39,6 @@ def test_node_version(auto_container):
                 build_command="npm ci && npm test",
             ),
             GitRepositoryBuild(
-                repository_url="https://github.com/chalk/chalk.git",
-                build_command="npm install && npm test",
-            ),
-            GitRepositoryBuild(
                 repository_url="https://github.com/tj/commander.js.git",
                 build_command="npm ci && npm test && npm run lint",
             ),


### PR DESCRIPTION
Remove the chalk repository from the NodeJS tests as they are broken on Node12.

* Related ticket: https://progress.opensuse.org/issues/121147