### PR TITLE
Switch to SLE BCI language pack for unit testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,18 +48,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python_version: ["3.6", "3.9", "3.10"]
+    container:
+      image: registry.suse.com/bci/python:${{ matrix.python_version }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python_version }}
+      - name: checkout source code
+        uses: actions/checkout@v3
       - name: Install tox
         run: |
-          python -m ensurepip
-          pip install tox
-      - run: 'tox -e py${PY_VER//\./}-unit -- -n auto'
+          python3 --version
+          python3 -m ensurepip
+          python3 -m pip install tox
+      - run: 'tox -e py$(echo $PY_VER | tr -d . )-unit -- -n auto'
         env:
+          SETUPTOOLS_SCM_PRETEND_VERSION: 1.2.3
           PY_VER: ${{ matrix.python_version }}
 
   documentation:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py36,py37,py38,py39,py310}-unit, build, all, base, fips, init, dotnet, python, ruby, node, go, openjdk, openjdk_devel, rust, busybox, 389ds, metadata, minimal, multistage, repository, doc, lint, get_urls, pcp
+envlist = {py36,py39,py310}-unit, build, all, base, fips, init, dotnet, python, ruby, node, go, openjdk, openjdk_devel, rust, busybox, 389ds, metadata, minimal, multistage, repository, doc, lint, get_urls, pcp
 isolated_build = True
 skip_missing_interpreters = True
 
@@ -31,7 +31,7 @@ passenv =
 commands =
     pytest -vv tests/test_{envname}.py --junitxml={toxinidir}/junit_{envname}.xml []
 
-[testenv:{py36,py37,py38,py39,py310}-unit]
+[testenv:{py36,py39,py310}-unit]
 commands =
     pytest -n auto tests/test_unit.py --junitxml={toxinidir}/junit_unit.xml []
 


### PR DESCRIPTION
The GitHub runners no longer support 3.6, and 3.11 is the default python version nowadays.