### PR TITLE
Improve podman setup for build in latest ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,7 +109,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
-      - name: configure podman to verify gpg signatures
+      - name: Install necessary dependencies
+        if: ${{ matrix.container_runtime == 'PODMAN' }}
+        run: |
+          sudo apt update && sudo apt install podman
+          sudo mkdir -p /etc/containers/registries.d/
+      - name: configure podman to validate sigstore signatures
         if: ${{ matrix.container_runtime == 'PODMAN' }}
         run: |
           cat << EOF | sudo tee /etc/containers/registries.d/opensuse.yaml


### PR DESCRIPTION
The podman builds are now failing because the registries.d directory no longer exists. install podman explicitly and also create the directory for more reliable builds.