### PR TITLE
389ds is considered as L3 supported container

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -478,6 +478,7 @@ L3_CONTAINERS = [
     RUBY_25_CONTAINER,
     RUST_1_64_CONTAINER,
     RUST_1_65_CONTAINER,
+    CONTAINER_389DS,
 ]
 
 #: Containers that are directly pulled from registry.suse.de


### PR DESCRIPTION
`LABEL com.suse.supportlevel="l3"` is set by
https://build.suse.de/request/show/285987

- failure: https://openqa.suse.de/tests/10210286#step/_root_BCI-tests_metadata_podman/5