### PR TITLE
Remove the need for skopeo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,6 @@ What do I need to contribute?
 * tox
 * go
 * docker and/or podman+buildah
-* skopeo (only required for the metadata tests)
 * vagrant (optional, can be used to test FIPS mode and registered hosts)
 
 How can I run the tests?

--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -339,7 +339,7 @@ INIT_CONTAINER = create_BCI(
 )
 
 PCP_CONTAINER = create_BCI(
-    build_tag="suse/pcp:5.2.2",
+    build_tag="suse/pcp:5",
     extra_marks=[
         pytest.mark.skipif(DOCKER_SELECTED, reason="only podman is supported")
     ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ markers = [
     'bci/dotnet-aspnet_6.0',
     'bci/dotnet-aspnet_7.0',
     'suse/389-ds_2.0',
-    'suse/pcp_5.2.2',
+    'suse/pcp_5',
     'bci/rust_1.65',
     'bci/rust_1.66',
     'bci/rust_1.67',

--- a/tests/test_multistage.py
+++ b/tests/test_multistage.py
@@ -194,10 +194,15 @@ ENTRYPOINT ["/app/entrypoint.sh"]
 \x1b[40m\x1b[32minfo\x1b[39m\x1b[22m\x1b[49m: Microsoft.Hosting.Lifetime[0]
       Content root path: /app
 """,
-            marks=pytest.mark.skipif(
-                LOCALHOST.system_info.arch != "x86_64",
-                reason="The dotnet containers are only available for x86_64",
-            ),
+            marks=[
+                pytest.mark.skipif(
+                    LOCALHOST.system_info.arch != "x86_64",
+                    reason="The dotnet containers are only available for x86_64",
+                ),
+                pytest.mark.skip(
+                    reason="This relies on .Net 5, which reached Eol, see: https://github.com/phillipsj/adventureworks-k8s-sample/issues/4"
+                ),
+            ],
         ),
     ],
     indirect=["host_git_clone"],


### PR DESCRIPTION
pytest_container can now inspect containers directly. Thereby we do not need to rely on skopeo for the tests anymore