### PR TITLE
XFAIL when the reference image does not exist

### DIFF
--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -408,4 +408,8 @@ def test_reference(
         version, _ = version_release.split("-")
         ref = f"{name}:{version}"
 
-    LOCALHOST.run_expect([0], f"{container_runtime.runner_binary} pull {ref}")
+    output = LOCALHOST.run_expect(
+        [0, 125], f"{container_runtime.runner_binary} pull {ref}"
+    )
+    if output.rc != 0:
+        pytest.xfail("Reference container image is not published yet")


### PR DESCRIPTION
```
[gw0] [ 16%] PASSED tests/test_metadata.py::test_general_labels[container6-golang-bci] 
tests/test_metadata.py::test_image_type_label[container6-bci] 
[gw2] [ 33%] FAILED tests/test_metadata.py::test_disturl_can_be_checked_out[bci/golang:1.20 from registry.opensuse.org/devel/bci/sle-15-sp4/containerfile/bci/golang:1.20] 
[gw1] [ 50%] PASSED tests/test_metadata.py::test_disturl[container6-golang-bci] 
tests/test_metadata.py::test_reference[container6-golang-bci] 
[gw3] [ 66%] PASSED tests/test_metadata.py::test_l3_label[bci/golang:1.20 from registry.opensuse.org/devel/bci/sle-15-sp4/containerfile/bci/golang:1.20] 
[gw1] [ 83%] XFAIL tests/test_metadata.py::test_reference[container6-golang-bci]    <-------
[gw0] [100%] PASSED tests/test_metadata.py::test_image_type_label[container6-bci] 
```