### PR TITLE
Switch to new devel:BCI key

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,26 +161,46 @@ jobs:
 
           cat << EOF > /tmp/devel_bci.key
           -----BEGIN PGP PUBLIC KEY BLOCK-----
-          Version: GnuPG v2.0.15 (GNU/Linux)
 
-          mQENBGCJZzgBCADHMlE3qg9CVEtykdTkLk+/rntTMIcLnouu5rSMaIykEb35H4lL
-          gieN2wBzDa5lQlh4a2fq5IHpDDCPORUUmmEbUL1zqO8eOqOYfYWQGEY/l+vFmg5r
-          75nCgKLSD1ufp1bdPGNKJioS8XWI/SUsuaoiIDrCidCWx1GjAIjKDLgW8o6jaZ+8
-          Sp9LmQfCuOu629ydmDGnxAiwmJPM0ECSYjmsUL4639CI93WrgaWSp030iDSod55u
-          IW2MxaBVzDUmauKBpdHbc/xfM7f5Dh1HYKry1KO3c5hTNYODM6FgaREJazgafNCe
-          M4ZbMlkFHhMLl3nnrAhhHL2/KPyJs1QfHYGXABEBAAG0NGRldmVsOkJDSSBPQlMg
-          UHJvamVjdCA8ZGV2ZWw6QkNJQGJ1aWxkLm9wZW5zdXNlLm9yZz6JAT4EEwEIACgF
-          AmCJZzgCGwMFCQQesAAGCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEJpjxEY1
-          byhESq0H/AlUlJGp2nlFHdgwi6hL0N7DXYAarw2lHs3+pFvArveR/0b/u6Arz8YS
-          6Z2oWhne57ou0+DzmtyHHpZvLbNQV0455Jzjc28K9lt3fSyGyU/e0fCaL+oUCNFi
-          dBVbE6XkK1SQCVWqLmj5ZxaLhiyRDwBgOerxvTeH3OnBgadi5ApMJZ5p3qryfZ2j
-          /FumjZPKU9HolI3l0wogBfPOHvEwzKoLiiT+YS3+gWTWdR81vTTYJZMQJUtuLvfA
-          kmMDrWbvpYdrUO1rXdGYjbhFtFRsFLiEY82AGtzS1rVMuyvPUhWOaV/oZ+MEJRmL
-          re/RHy1/vnXyfW5pB635hKGt30zBjeSIRgQTEQIABgUCYIlnOQAKCRA7MBG3a51l
-          I934AJ91pSfBUERzkO8fHiz6Bw0nr01BHgCgkYx950ZzbyPpzi5rM5Cw7gzj0JY=
-          =vSvO
+          mQINBGQa2Y4BEAC+VBw/6hJCCd+JlrngmHvAS2dbzz0dk0dh6rK7mhuuQTmTbJex
+          eY2tmFfcg3wp78P586H7WwE+0fLf7KEuIsWK8/YCpe7Ld/WycQkkJiW7EhbW4+uu
+          6EKBw1B7ZFDaJJ71UDaXbMECepV/YEnsZgu38vGWZPUfOHbIDS5M0j9Xo7COG7/I
+          jzs0Ml+G8hAk1cJ5AxjLycyINKHnglrx855/AW1xjO04Da6/NZ5grvCQBNcpLaH5
+          Y8eUvNVQ6SdBwo9xR8hCTsUe5TpB5Gf4CXNPMdG6f1wDbmRw6hYw4Tbvjjlg8yhO
+          XS76OURH3AiYTrP7SDVrgOy8tsVtSk1+1zvJ5VFjKbS8N3//XOkSJYSD/MxjN+bb
+          jwsqK6FEYBS1MiIX/6bYo5j/bVDzp/jZ9ocPB623E9CGwgH0NDrs+5M3la/j+vIq
+          wjwXpWuwdefVjhvIDYgSZQQRx880RLo31Zr6Vfpas1JXIzDq6uSWAyx23rKmQr9N
+          ctU1qHNB5CdKDR/zAMjuFvy1o13zTmfo1CrRn9J//Kiy2EnfsKOFssfYs9TgL22k
+          qdsCXNa0xvXbeLDehQwQvxeWTLyGMJGwPqoTXVv3EhEhrLClB5FOJurwfArd24ze
+          qvVsKJrADEWvO3a1KHkX4h82qBDGJdQDK5iMajLJeQciYVhT5pHHMdMbmQARAQAB
+          tDRkZXZlbDpCQ0kgT0JTIFByb2plY3QgPGRldmVsOkJDSUBidWlsZC5vcGVuc3Vz
+          ZS5vcmc+iQJUBBMBCAA+FiEE4t9p2tF8+S+4jG5wMG+YHbRrR8MFAmQa2Y4CGwMF
+          CQQesAAFCwkIBwIGFQoJCAsCBBYCAwECHgECF4AACgkQMG+YHbRrR8NWlRAAmPQ6
+          0Ac1LDrAD+NJ/Z/7TzLg6dpkC5JNDkwNSoSyfKiN3ow8265mF8XM7502ZCDeOr0p
+          GDisbOTSdOWI981TQ0MRtRWsBzjHkkl4CuxoGHC0X0Q1wjbKy8BfnfAlmNF/l8PL
+          Ykm15xndHzE1oIxJ0V5KKA0v4vKJkSNsZ9Ye0IyzICpkWoUfqeg3rnSpwV/MvQTf
+          2as9mXj8TSAuR47rsWtivljhGnFpTyvvWw30bDItpB5EYlCVjPlj1t2wX/fHkNX6
+          0Gdkrwhml67pk7v03+ngbKDAPGrcq5EKLaNfL5T5cOx5GzUrjOH7OpqdnR9Lg5Ix
+          IpcfAfkeY+E+ALMvfyhVmhMRhGMgiv0wTL/H11/K1rvXaVYznoKG0G/7cCuorDBf
+          ind5PkGJTu+3Fs7N6eQZntVwXoBxkGWb8b6voFv22u55svToTX28pkDVm5EJNZnv
+          xfFUhX6m+CFdh138aX2LFYQCsF/T8jM4j+ukHTQ+m8F+eRrhqoBjWkvHZ3EionpL
+          F+1LGdEn25qMej++OkAm6D5dV/yQaP1rjpdHwQEZ6GntVl2ngagoF8zQIJ6rXe15
+          FvZ9AvL+gta8vxluDTPUK3DIg4jdwFb8WT2R0rOPUaItheOaCXxxcr6wPbHHLHC1
+          LKPO+oy9938+sUaaC/DEO+vwPOkSwrBw/0htilmJAjMEEwEIAB0WIQTMNcw9NeWj
+          ZD5UWkPPC5KM3tZPOwUCZBrZkQAKCRDPC5KM3tZPO3QbD/4kEsEW2tBxus+AfT/P
+          r9B1iiHgOu9e6ixvmEcqF4bU3ykAmo7DH/E+oqW6vx97DnYgKleJJ9IVD6gTyhYJ
+          7Z+uPoJOWNND94Afiq+R1lobPs9rOpSVT34NmNzNgxdmmz6+z1GLrrVGUihdYSDc
+          1DmdIu90IFtuaSW8+UaCg41awVtVOOYnPaCoDncbuZD0MDaVDsaN0G9Xj81NFZJu
+          DG7ljqxg24LC9+iw3LRqaOkWX7SbS0s+PdLTPgnUBfivpOi0rKbB06WsCsigV24B
+          lyj11nkuOdYAUa48Q3U1yfxIiecYto0O+VPq/M0ICAzTqUg2Bh4Du98EmS+zBhbM
+          vjAcqC2TRBjyVAtsvWJ0O51d0iWUWsOBVwSoMRWq2iPxh4qRBNFQGLUWtrkNSKh/
+          ex2LgWbLGZY8XHWUwK2GoHN/uNywqYd/4PgDewDJYWnGB33EaucKkMuBJkoYK2mG
+          fGkSHjKUHfUp+FWM8QlgxlavNob7ltvTEV8kp88w9MfSfdy6Z9MQ63Z/DvU1KLhO
+          llCkXgpMXn2dPPjcsE/OWVIVk833q0gWzf3touFhQSHMKtcdXl3bBj/vvzAkE0QV
+          9vVS3rgOtcGCbAdfdEf+/mpukHkhZGVKMlipnDM/Rd2GZYckP/5UZ/9/CKIS69B5
+          hLNKnq/uYWnF2uUesgKloRegdg==
+          =L0Kw
           -----END PGP PUBLIC KEY BLOCK-----
-          EOF
 
       - name: Run tox job
         run: sudo --preserve-env tox -e ${{ matrix.toxenv }}


### PR DESCRIPTION
This key is a RSA 4096 bits state of affairs key:

pub   rsa4096 2023-03-22 [SC] [expires: 2025-05-30]
      E2DF69DAD17CF92FB88C6E70306F981DB46B47C3
uid           devel:BCI OBS Project <devel:BCI@build.opensuse.org>
sig        306F981DB46B47C3 2023-03-22   [selfsig]
sig        CF0B928CDED64F3B 2023-03-22   [User ID not found]