### PR TITLE
Automatically cancel the tox integration tests on force pushes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,10 @@ on:
   pull_request:
   repository_dispatch:
 
+concurrency:
+  group: integration-tests-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   format:
     name: Ensure code is black formatted


### PR DESCRIPTION
Uses this setting: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency