### PR TITLE
Skip CI on pushes to main branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,9 +4,6 @@ name: CI
 on:
   schedule:
     - cron: '44 4 */2 * *'
-  push:
-    branches:
-      - "main"
   pull_request:
   repository_dispatch:
 


### PR DESCRIPTION
main branch is protected and we require PRs - so pre-merge CI should be enough, post-merge is just wasting resources