### PR TITLE
Require psycopg2 version >= 2.9.6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,9 @@ deps =
 [testenv]
 deps =
     {[common]deps}
-    psycopg2
+    # Require a recent version of psycopg2 to avoid poo#128900
+    # 2.9.6 was the most up-to-date when adding this dependency
+    psycopg2 >= 2.9.6
 allowlist_externals =
     docker
     podman


### PR DESCRIPTION
To avoid the `ModuleNotFoundError for 'ConfigParser'` we require `psycopg2` to be a more recent version.

* Related ticket: https://progress.opensuse.org/issues/128900
* Related failure (example): https://openqa.suse.de/tests/11072489#step/bci_test_podman/37
* Verification runs: [SLES15-SP4 aarch64](https://openqa.suse.de/tests/11073975) | [SLES12-SP5 x86_64](https://openqa.suse.de/tests/11074493)