### PR TITLE
Increase timeout for zypper

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -118,7 +118,7 @@ def test_zypper_dup_works(container_per_test: ContainerData) -> None:
     """
     container_per_test.connection.run_expect(
         [0],
-        "timeout 1m zypper -n dup --from SLE_BCI -l -d -D "
+        "timeout 2m zypper -n dup --from SLE_BCI -l -d -D "
         "--no-allow-vendor-change --allow-downgrade --no-allow-arch-change",
     )
 


### PR DESCRIPTION
Increase the timeout for zypper to prevent false positives on some slow architectures.

Example failues: [1](https://openqa.suse.de/tests/11265480#step/bci_test_podman/31) [2](https://openqa.suse.de/tests/11265479#step/bci_test_podman/37) [3](https://openqa.suse.de/tests/11265481#step/bci_test_podman/37)