### PR TITLE
xfail gem install sqlite3 only on x86_64 & aarch64

### DIFF
--- a/tests/test_ruby.py
+++ b/tests/test_ruby.py
@@ -1,9 +1,16 @@
 import pytest
+from pytest_container.runtime import LOCALHOST
 
 from bci_tester.data import RUBY_25_CONTAINER
 
 
 CONTAINER_IMAGES = [RUBY_25_CONTAINER]
+
+
+_NON_X86_64_OR_AARCH64_SKIP = pytest.mark.skipif(
+    LOCALHOST.system_info.arch in ("x86_64", "aarch64"),
+    reason="The sqlite3 gem is not installable on x86_64 and aarch64, bsc#1203692",
+)
 
 
 def test_ruby_version(auto_container):
@@ -42,12 +49,7 @@ def test_lang_set(auto_container):
             "rails -v '<7.0'",
             marks=pytest.mark.xfail(reason="rails 6 is not installable"),
         ),
-        pytest.param(
-            "sqlite3",
-            marks=pytest.mark.xfail(
-                reason="sqlite3 gem fails to install, bsc#1203692"
-            ),
-        ),
+        pytest.param("sqlite3", marks=_NON_X86_64_OR_AARCH64_SKIP),
         "rspec-expectations",
         "diff-lcs",
         "rspec-mocks",


### PR DESCRIPTION
It looks like the newest version of the sqlite3 gem can be installed from source, but on x86_64 and aarch64 there are prebuild binaries which fail to install. Thus we work around this by xfailing on x86_64 & aarch64 only.

This fixes https://github.com/SUSE/BCI-tests/issues/258 (well, sorta-kinda…)