### PR TITLE
Remove old authentications for RHEL7

### DIFF
--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -52,14 +52,6 @@ def _generate_test_matrix() -> List[ParameterSet]:
             if pg_user:
                 env["POSTGRES_USER"] = pg_user
 
-            # postgres on RHEL7 is too ancient to support scram-sha-256 and only
-            # works with md5 auth
-            if (
-                LOCALHOST.system_info.distribution == "rhel"
-                and LOCALHOST.system_info.release.startswith("7.")
-            ):
-                env["POSTGRES_HOST_AUTH_METHOD"] = "md5"
-
             params.append(
                 pytest.param(
                     DerivedContainer(


### PR DESCRIPTION
Remove the md5 authentication method for RHEL7 because it was never working as expected and is not needed anymore.

* Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/17364