### PR TITLE
Install util-linux for cassandra tests

### DIFF
--- a/tests/test_openjdk.py
+++ b/tests/test_openjdk.py
@@ -229,6 +229,10 @@ def test_jdk_cassandra(container_per_test):
 
     logs = "/var/log/cassandra.log"
 
+    container_per_test.connection.run_expect(
+        [0], f"zypper --non-interactive install util-linux"
+    )
+
     cassandra_versions = container_per_test.connection.check_output(
         "git ls-remote --tags https://gitbox.apache.org/repos/asf/cassandra.git"
     )


### PR DESCRIPTION
cassandra is calling "getopt" which is coming from util-linux which might not be available (currently missing in opensuse/tumbleweed image)