### PR TITLE
Provide slightly better setup.cfg metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,26 @@
 [metadata]
 name = bci-tester
+description = Test tooling to functionally test the BCI containers
+long_description = file: README.rst
+url = https://github.com/SUSE/BCI-tests
+license = Apache-2.0
+license_file = LICENSE
+maintainer = SUSE, LLC
+maintainer_email = containers-bugowner@suse.de
+classifiers =
+        Development Status :: 5 - Production/Stable
+        Intended Audience :: Developers
+        License :: OSI Approved :: Apache-2.0 License
+        Operating System :: OS Independent
+        Programming Language :: Python
+        Programming Language :: Python :: 3
+        Programming Language :: Python :: 3.6
+        Programming Language :: Python :: 3.7
+        Programming Language :: Python :: 3.8
+        Programming Language :: Python :: 3.9
+        Programming Language :: Python :: 3.10
+        Programming Language :: Python :: 3.11
+
 
 [options]
 packages = bci_tester


### PR DESCRIPTION
This avoids setuptools warnings in the CI logs about missing metadata