### PR TITLE
Always use curl -sf

### DIFF
--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -23,7 +23,7 @@ def test_registry_service(
 
     out = json.loads(
         host.check_output(
-            f"curl -sb -H 'Accept: application/json' http://localhost:{host_port}/v2/_catalog"
+            f"curl -sfb -H 'Accept: application/json' http://localhost:{host_port}/v2/_catalog"
         )
     )
     assert str(out) == "{'repositories': []}"
@@ -50,7 +50,7 @@ def test_registry_service(
     host.run_expect([0], f"{engine} push {force_http_mode} {container_path}")
     out = json.loads(
         host.check_output(
-            f"curl -sb -H 'Accept: application/json' http://localhost:{host_port}/v2/_catalog"
+            f"curl -sfb -H 'Accept: application/json' http://localhost:{host_port}/v2/_catalog"
         )
     )
     assert str(out) == "{'repositories': ['test_container']}"

--- a/tests/test_openjdk.py
+++ b/tests/test_openjdk.py
@@ -249,7 +249,7 @@ def test_jdk_cassandra(container_per_test):
 
     container_per_test.connection.run_expect(
         [0],
-        f"curl -fOL https://downloads.apache.org/cassandra/{cassandra_version}/apache-cassandra-{cassandra_version}-bin.tar.gz",
+        f"curl -sfOL https://downloads.apache.org/cassandra/{cassandra_version}/apache-cassandra-{cassandra_version}-bin.tar.gz",
     )
 
     container_per_test.connection.run_expect(

--- a/tests/test_pcp.py
+++ b/tests/test_pcp.py
@@ -56,7 +56,7 @@ def test_call_pmproxy(auto_container_per_test):
     if LOCALHOST.exists("curl"):
         assert LOCALHOST.run_expect(
             [0],
-            f"curl -s http://localhost:{port}/metrics?names=mem.physmem",
+            f"curl -sf http://localhost:{port}/metrics?names=mem.physmem",
         )
 
 

--- a/tests/test_php.py
+++ b/tests/test_php.py
@@ -48,7 +48,7 @@ RUN set -e; zypper -n in $PHPIZE_DEPS oniguruma-devel libicu-devel gcc-c++ php8-
 
 RUN set -euo pipefail; \
     zypper -n in tar; \
-    curl -OLf "https://releases.wikimedia.org/mediawiki/${MEDIAWIKI_MAJOR_VERSION}/mediawiki-${MEDIAWIKI_VERSION}.tar.gz"; \
+    curl -sfOL "https://releases.wikimedia.org/mediawiki/${MEDIAWIKI_MAJOR_VERSION}/mediawiki-${MEDIAWIKI_VERSION}.tar.gz"; \
     tar xvzf "mediawiki-${MEDIAWIKI_VERSION}.tar.gz"; \
     rm "mediawiki-${MEDIAWIKI_VERSION}.tar.gz"; \
     pushd "mediawiki-${MEDIAWIKI_VERSION}/"; mv * ..; popd; rmdir "mediawiki-${MEDIAWIKI_VERSION}"; \
@@ -56,7 +56,7 @@ RUN set -euo pipefail; \
     chown --recursive wwwrun data; \
     zypper -n clean; rm -rf /var/log/{zypp*,suseconnect*}
 
-HEALTHCHECK --interval=10s --timeout=1s --retries=10 CMD curl --fail http://localhost
+HEALTHCHECK --interval=10s --timeout=1s --retries=10 CMD curl -sf http://localhost
 EXPOSE 80
 """,
 )
@@ -109,8 +109,8 @@ RUN set -eux; \
 # MediaWiki setup
 RUN set -eux; \
     zypper -n in dirmngr gzip; \
-        curl -fSL "https://releases.wikimedia.org/mediawiki/${MEDIAWIKI_MAJOR_VERSION}/mediawiki-${MEDIAWIKI_VERSION}.tar.gz" -o mediawiki.tar.gz; \
-        curl -fSL "https://releases.wikimedia.org/mediawiki/${MEDIAWIKI_MAJOR_VERSION}/mediawiki-${MEDIAWIKI_VERSION}.tar.gz.sig" -o mediawiki.tar.gz.sig; \
+        curl -sfSL "https://releases.wikimedia.org/mediawiki/${MEDIAWIKI_MAJOR_VERSION}/mediawiki-${MEDIAWIKI_VERSION}.tar.gz" -o mediawiki.tar.gz; \
+        curl -sfSL "https://releases.wikimedia.org/mediawiki/${MEDIAWIKI_MAJOR_VERSION}/mediawiki-${MEDIAWIKI_VERSION}.tar.gz.sig" -o mediawiki.tar.gz.sig; \
         export GNUPGHOME="$(mktemp -d)"; \
         # gpg key from https://www.mediawiki.org/keys/keys.txt
         gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
@@ -323,7 +323,7 @@ def test_mediawiki_php_apache(
     """
     host.run_expect(
         [0],
-        f"curl --fail http://localhost:{container_per_test.forwarded_ports[0].host_port}",
+        f"curl -sf http://localhost:{container_per_test.forwarded_ports[0].host_port}",
     )
 
 
@@ -343,5 +343,5 @@ def test_mediawiki_fpm_build(
     """
     host.run_expect(
         [0],
-        f"curl --fail http://localhost:{pod_per_test.forwarded_ports[0].host_port}",
+        f"curl -sf http://localhost:{pod_per_test.forwarded_ports[0].host_port}",
     )

--- a/tests/test_ruby.py
+++ b/tests/test_ruby.py
@@ -118,7 +118,7 @@ def test_rails_template(auto_container_per_test):
 
     curl_localhost = auto_container_per_test.connection.run_expect(
         [0],
-        "cd /hello/ && (rails server > /dev/null &) && curl --retry 5 --retry-connrefused  http://localhost:3000",
+        "cd /hello/ && (rails server > /dev/null &) && curl -sf --retry 5 --retry-connrefused  http://localhost:3000",
     )
 
     assert "Ruby on Rails" in curl_localhost.stdout.strip()


### PR DESCRIPTION
We don't want fails to be interpreted as success, so we need to run with --fail. and as the curj output isn't tested, we can use -s for consistency everywhere.