### PR TITLE
Skip testing reference when TARGET is not testing released containers

### DIFF
--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -453,6 +453,13 @@ def test_reference(
         else:
             assert reference[:22] == "registry.suse.com/bci/"
 
+    # only test if our testing target is released - otherwise we'll just fail on
+    # containers that are not yet ever released
+    if not container.container.baseurl.startswith(reference.partition(":")[0]):
+        pytest.skip(
+            f"reference {reference} not checked for in TARGET={container.container.baseurl}"
+        )
+
     # for the OS versioned containers we'll get a reference that contains the
     # current full version + release, which has not yet been published to the
     # registry (obviously). So instead we just try to fetch the current major
@@ -464,4 +471,6 @@ def test_reference(
         version, _ = version_release.split("-")
         ref = f"{name}:{version}"
 
-    LOCALHOST.run_expect([0], f"{container_runtime.runner_binary} pull {ref}")
+    LOCALHOST.run_expect(
+        [0], f"{container_runtime.runner_binary} manifest inspect {ref}"
+    )


### PR DESCRIPTION
We have frequently CI pipeline failures when we release a container for the first time, as it is checking for a reference being accessible that does not yet exist, and it would become accessible would the CI pipeline go through. This requires manual workarounds and overriding a release without proper testing, which isn't sensible.

As this is the only test that fails on an unreleased container, lets skip it in that case.