### PR TITLE
Remove go1.20-openssl

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -313,7 +313,6 @@ GOLANG_CONTAINERS = [
     )
     for golang_version, stability in (
         ("1.20", "oldstable"),
-        ("1.20-openssl", "oldstable"),
         ("1.21", "stable"),
         # does not exist yet (as of 2023/08/15)
         # ("1.21-openssl", "stable"),


### PR DESCRIPTION
Disable the `go1.20-openssl` container as it was not yet released to the CR project.

* See https://suse.slack.com/archives/C02AF8LALDA/p1693401007506499?thread_ts=1693399023.295749&cid=C02AF8LALDA
* VR: http://duck-norris.qe.suse.de/tests/13498