### PR TITLE
Revert "Remove go1.20-openssl"

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -313,6 +313,7 @@ GOLANG_CONTAINERS = [
     )
     for golang_version, stability in (
         ("1.20", "oldstable"),
+        ("1.20-openssl", "oldstable"),
         ("1.21", "stable"),
         # does not exist yet (as of 2023/08/15)
         # ("1.21-openssl", "stable"),


### PR DESCRIPTION
Reverts SUSE/BCI-tests#295