### PR TITLE
Add softfailure for kured on non-x86_64

### DIFF
--- a/tests/test_go.py
+++ b/tests/test_go.py
@@ -44,6 +44,10 @@ def test_go_version(auto_container):
             repository_url="https://github.com/weaveworks/kured.git",
             repository_tag="1.13.2",
             build_command="make bootstrap-tools kured && go test -race ./...",
+            marks=pytest.mark.xfail(
+                condition=LOCALHOST.system_info.arch != "x86_64",
+                reason="Currently broken on arch != x86_64 (https://github.com/kubereboot/kured/issues/823)",
+            ),
         ).to_pytest_param(),
     ],
     indirect=["container_git_clone"],


### PR DESCRIPTION
Adds a softfailure for kured, which is currently broken on non-x86_64 systems.

* Verification run [aarch64](https://openqa.suse.de/tests/12016912#step/bci_test_podman/57)