### PR TITLE
Remove skipping of tests as we rotated the broken image out

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -126,9 +126,6 @@ def test_lifecycle(auto_container):
 
     assert auto_container.connection.file(f"{lifecycle_dir}/").is_directory
 
-    if "rust:oldstable" in auto_container.container.get_base().url:
-        pytest.skip("bsc#1215834")
-
     rpmqpack = auto_container.connection.run_expect(
         [0], "rpm -qa --qf '%{NAME},%{VERSION}\n'"
     ).stdout.splitlines()


### PR DESCRIPTION
oldstable is now on an image that doesn't have the issue with outdated gcc anymore.