### PR TITLE
Use check_output() where possible

### DIFF
--- a/bci_tester/util.py
+++ b/bci_tester/util.py
@@ -11,10 +11,7 @@ def get_host_go_version(host) -> Version:
     # output of go version:
     # go version go1.19.1 linux/amd64
     return Version.parse(
-        host.run_expect([0], "go version")
-        .stdout.strip()
-        .split()[2]
-        .replace("go", "")
+        host.check_output("go version").split()[2].replace("go", "")
     )
 
 
@@ -69,6 +66,4 @@ def get_repos_from_zypper_xmlout(zypper_xmlout: str) -> List[Repository]:
 
 def get_repos_from_connection(con) -> List[Repository]:
     """Gets the list of repositories given a testinfra connection."""
-    return get_repos_from_zypper_xmlout(
-        con.run_expect([0], "zypper -x repos").stdout
-    )
+    return get_repos_from_zypper_xmlout(con.check_output("zypper -x repos"))

--- a/tests/test_389ds.py
+++ b/tests/test_389ds.py
@@ -37,9 +37,8 @@ def test_ldapwhoami(auto_container_per_test):
     host_port = auto_container_per_test.forwarded_ports[0].host_port
     if LOCALHOST.exists("ldapwhoami"):
         assert (
-            LOCALHOST.run_expect(
-                [0],
+            LOCALHOST.check_output(
                 f"ldapwhoami -H ldap://127.0.0.1:{host_port} -x -D 'uid=demo_user,ou=people,dc=example,dc=com' -w password",
-            ).stdout.strip()
+            )
             == "dn: uid=demo_user,ou=people,dc=example,dc=com"
         )

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -72,18 +72,18 @@ def test_os_release(auto_container):
                 assert (
                     datetime.datetime.now()
                     - datetime.datetime.strptime(
-                        auto_container.connection.run_expect(
-                            [0], f". /etc/os-release && echo ${var_name}"
-                        ).stdout.strip(),
+                        auto_container.connection.check_output(
+                            f". /etc/os-release && echo ${var_name}"
+                        ),
                         "%Y%m%d",
                     )
                 ).days < 10
                 continue
 
         assert (
-            auto_container.connection.run_expect(
-                [0], f". /etc/os-release && echo ${var_name}"
-            ).stdout.strip()
+            auto_container.connection.check_output(
+                f". /etc/os-release && echo ${var_name}"
+            )
             == expected_value
         )
 
@@ -127,17 +127,17 @@ def test_lifecycle(auto_container):
 
     assert auto_container.connection.file(f"{lifecycle_dir}/").is_directory
 
-    rpmqpack = auto_container.connection.run_expect(
-        [0], "rpm -qa --qf '%{NAME},%{VERSION}\n'"
-    ).stdout.splitlines()
+    rpmqpack = auto_container.connection.check_output(
+        "rpm -qa --qf '%{NAME},%{VERSION}\n'"
+    ).splitlines()
     installed_binaries = {}
     for pack in rpmqpack:
         rpm_name, _, rpm_version = pack.partition(",")
         installed_binaries[rpm_name] = rpm_version
 
-    for entry in auto_container.connection.run_expect(
-        [0], f"cat {lifecycle_dir}/*.lifecycle"
-    ).stdout.splitlines():
+    for entry in auto_container.connection.check_output(
+        f"cat {lifecycle_dir}/*.lifecycle"
+    ).splitlines():
         entry = entry.partition("#")[0]
         if not entry.strip() or "," not in entry:
             continue
@@ -255,9 +255,9 @@ def test_zypper_verify_passes(container_per_test: ContainerData) -> None:
     """
     assert (
         "Dependencies of all installed packages are satisfied."
-        in container_per_test.connection.run_expect(
-            [0], "timeout 5m env LC_ALL=C zypper -n verify -D"
-        ).stdout.strip()
+        in container_per_test.connection.check_output(
+            "timeout 5m env LC_ALL=C zypper -n verify -D"
+        )
     )
 
 

--- a/tests/test_busybox.py
+++ b/tests/test_busybox.py
@@ -77,22 +77,16 @@ def test_echo_cat_grep_pipes(auto_container):
 
 def test_ps(auto_container):
     """Check if the `ps` command yields some output"""
-    assert "root" in auto_container.connection.run_expect([0], "ps").stdout
+    assert "root" in auto_container.connection.check_output("ps")
 
 
 def test_base32_64(auto_container):
     """Ensure the base32 and base64 commands are returning the correct result for a given "test" string"""
-    assert (
-        "ORSXG5AK"
-        in auto_container.connection.run_expect(
-            [0], "echo test | base32"
-        ).stdout
+    assert "ORSXG5AK" in auto_container.connection.check_output(
+        "echo test | base32"
     )
-    assert (
-        "dGVzdAo="
-        in auto_container.connection.run_expect(
-            [0], "echo test | base64"
-        ).stdout
+    assert "dGVzdAo=" in auto_container.connection.check_output(
+        "echo test | base64"
     )
 
 

--- a/tests/test_dotnet.py
+++ b/tests/test_dotnet.py
@@ -107,9 +107,7 @@ def test_dotnet_hello_world(container_per_test, msg):
         [0], "dotnet new console -o MyApp"
     )
     assert (
-        container_per_test.connection.run_expect(
-            [0], "cd MyApp && dotnet run"
-        ).stdout.strip()
+        container_per_test.connection.check_output("cd MyApp && dotnet run")
         == msg
     )
 
@@ -159,9 +157,9 @@ def test_dotnet_sdk_telemetry_deactivated(container_per_test):
     notice is present in the output of :command:`dotnet help`.
 
     """
-    dotnet_new_stdout = container_per_test.connection.run_expect(
-        [0], "dotnet help"
-    ).stdout.strip()
+    dotnet_new_stdout = container_per_test.connection.check_output(
+        "dotnet help"
+    )
     assert not re.search(r"telemetry", dotnet_new_stdout, re.IGNORECASE)
 
 
@@ -183,9 +181,9 @@ def test_microsoft_dotnet_repository(container_per_test):
 
     def get_pkg_list(extra_search_flags: str = "") -> List[str]:
         zypper_xml_out = ET.fromstring(
-            container_per_test.connection.run_expect(
-                [0], f"zypper -x se {extra_search_flags} -r {MS_REPO_NAME}"
-            ).stdout.strip()
+            container_per_test.connection.check_output(
+                f"zypper -x se {extra_search_flags} -r {MS_REPO_NAME}"
+            )
         )
         solvable_list = list(
             [

--- a/tests/test_fips.py
+++ b/tests/test_fips.py
@@ -139,9 +139,9 @@ def test_openssl_fips_hashes(container_per_test):
         assert FIPS_ERR_MSG in cmd.stderr
 
     for digest in FIPS_DIGESTS:
-        dev_null_digest = container_per_test.connection.run_expect(
-            [0], f"openssl {digest} /dev/null"
-        ).stdout
+        dev_null_digest = container_per_test.connection.check_output(
+            f"openssl {digest} /dev/null"
+        )
         assert (
             f"{digest.upper()}(/dev/null)= " in dev_null_digest
         ), f"unexpected digest of hash {digest}: {dev_null_digest}"

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -7,9 +7,6 @@ CONTAINER_IMAGES = (GIT_CONTAINER,)
 
 
 def test_git_version(auto_container):
-    assert (
-        "git version 2."
-        in auto_container.connection.run_expect(
-            [0], "git --version"
-        ).stdout.strip()
+    assert "git version 2." in auto_container.connection.check_output(
+        "git --version"
     )

--- a/tests/test_go.py
+++ b/tests/test_go.py
@@ -91,11 +91,8 @@ def test_go_get_binary_in_path(auto_container_per_test):
     auto_container_per_test.connection.run_expect(
         [0], "go install github.com/tylertreat/comcast@latest"
     )
-    assert (
-        "Comcast"
-        in auto_container_per_test.connection.run_expect(
-            [0], "comcast -version"
-        ).stdout
+    assert "Comcast" in auto_container_per_test.connection.check_output(
+        "comcast -version"
     )
 
 
@@ -105,12 +102,8 @@ def test_base_PATH_present(auto_container, container):
     present in he base container in the golang containers.
 
     """
-    path_in_go_container = auto_container.connection.run_expect(
-        [0], "echo $PATH"
-    ).stdout.strip()
-    path_in_base_container = container.connection.run_expect(
-        [0], "echo $PATH"
-    ).stdout.strip()
+    path_in_go_container = auto_container.connection.check_output("echo $PATH")
+    path_in_base_container = container.connection.check_output("echo $PATH")
     assert path_in_base_container in path_in_go_container
 
 

--- a/tests/test_helm.py
+++ b/tests/test_helm.py
@@ -8,10 +8,6 @@ CONTAINER_IMAGES = (HELM_CONTAINER,)
 
 def test_helm_version(auto_container, host, container_runtime):
     """Test that we can invoke `helm version` successfully."""
-    assert (
-        "GitTreeState"
-        in host.run_expect(
-            [0],
-            f"{container_runtime.runner_binary} run --rm {auto_container.image_url_or_id} version",
-        ).stdout.strip()
+    assert "GitTreeState" in host.check_output(
+        f"{container_runtime.runner_binary} run --rm {auto_container.image_url_or_id} version",
     )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -94,9 +94,7 @@ class TestSystemd:
         """
         Ensure :command:`systemd-detect-virt` detects the container runtime
         """
-        output = auto_container.connection.run_expect(
-            [0], "systemd-detect-virt"
-        ).stdout
+        output = auto_container.connection.check_output("systemd-detect-virt")
         runtime = container_runtime.runner_binary
         assert (
             runtime in output
@@ -147,9 +145,7 @@ class TestSystemd:
         """
         Ensure :command:`timedatectl` works as expected and the container timezone is UTC
         """
-        output = auto_container.connection.run_expect(
-            [0], "timedatectl"
-        ).stdout
+        output = auto_container.connection.check_output("timedatectl")
         assert re.search(
             r"Time zone:.*(Etc/UTC|UTC)", output
         ), "Time zone not set to UTC"

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -15,14 +15,10 @@ def test_node_version(auto_container):
     version of the installed :command:`node` binary.
 
     """
-    assert (
-        auto_container.connection.run_expect([0], "node -v")
-        .stdout.strip()
-        .replace("v", "")
-        .split(".")[0]
-        == auto_container.connection.run_expect(
-            [0], "echo $NODE_VERSION"
-        ).stdout.strip()
+    assert auto_container.connection.check_output("node -v").replace(
+        "v", ""
+    ).split(".")[0] == auto_container.connection.check_output(
+        "echo $NODE_VERSION"
     )
 
 

--- a/tests/test_openjdk_devel.py
+++ b/tests/test_openjdk_devel.py
@@ -67,10 +67,7 @@ def test_jdk_version(container, java_version: str):
     )
 
     assert (
-        container.connection.run_expect(
-            [0], "echo $JAVA_VERSION"
-        ).stdout.strip()
-        == java_version
+        container.connection.check_output("echo $JAVA_VERSION") == java_version
     )
 
 

--- a/tests/test_php.py
+++ b/tests/test_php.py
@@ -176,9 +176,8 @@ def test_install_php_extension_via_script(
         [0], f"docker-php-ext-install {extension}"
     )
 
-    assert (
-        extension
-        in auto_container_per_test.connection.run_expect([0], "php -m").stdout
+    assert extension in auto_container_per_test.connection.check_output(
+        "php -m"
     )
 
 
@@ -221,16 +220,13 @@ def test_zypper_install_php_extensions(
     """
     assert (
         extension_name
-        not in auto_container_per_test.connection.run_expect(
-            [0], "php -m"
-        ).stdout
+        not in auto_container_per_test.connection.check_output("php -m")
     )
     auto_container_per_test.connection.run_expect(
         [0], f"zypper -n in php{_PHP_MAJOR_VERSION}-{extension_name}"
     )
-    assert (
-        extension_name
-        in auto_container_per_test.connection.run_expect([0], "php -m").stdout
+    assert extension_name in auto_container_per_test.connection.check_output(
+        "php -m"
     )
 
 
@@ -253,9 +249,7 @@ def test_environment_variables(
     """
 
     def get_env_var(env_var: str) -> str:
-        return container_per_test.connection.run_expect(
-            [0], f"echo ${env_var}"
-        ).stdout.strip()
+        return container_per_test.connection.check_output(f"echo ${env_var}")
 
     php_pkg_version = container_per_test.connection.package(
         f"php{_PHP_MAJOR_VERSION}"
@@ -298,13 +292,9 @@ def test_cli_entry_point(
     """
     container_image.prepare_container(pytestconfig.rootpath)
 
-    assert (
-        "PHP_BINARY"
-        in host.run_expect(
-            [0],
-            f"{container_runtime.runner_binary} run --rm "
-            f"{container_image.url or container_image.container_id} -r 'print_r(get_defined_constants());'",
-        ).stdout
+    assert "PHP_BINARY" in host.check_output(
+        f"{container_runtime.runner_binary} run --rm "
+        f"{container_image.url or container_image.container_id} -r 'print_r(get_defined_constants());'",
     )
 
 

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -103,9 +103,9 @@ def test_postgres_db_env_vars(
     assert pgdata_f.user == "postgres"
     assert pgdata_f.mode == 0o700
 
-    assert container_per_test.connection.run_expect(
-        [0], "id -un"
-    ).stdout.strip() == (username or "root")
+    assert container_per_test.connection.check_output("id -un") == (
+        username or "root"
+    )
 
     try:
         conn = psycopg2.connect(

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -76,12 +76,12 @@ def test_python_version(auto_container):
     ``PYTHON_VERSION``.
 
     """
-    reported_version = auto_container.connection.run_expect(
-        [0], "python3 --version"
-    ).stdout.strip()
-    version_from_env = auto_container.connection.run_expect(
-        [0], "echo $PYTHON_VERSION"
-    ).stdout.strip()
+    reported_version = auto_container.connection.check_output(
+        "python3 --version"
+    )
+    version_from_env = auto_container.connection.check_output(
+        "echo $PYTHON_VERSION"
+    )
 
     assert reported_version == f"Python {version_from_env}"
 
@@ -92,12 +92,10 @@ def test_pip(auto_container):
 
     """
     assert auto_container.connection.pip.check().rc == 0
-    reported_version = auto_container.connection.run_expect(
-        [0], "pip --version"
-    ).stdout
-    version_from_env = auto_container.connection.run_expect(
-        [0], "echo $PIP_VERSION"
-    ).stdout.strip()
+    reported_version = auto_container.connection.check_output("pip --version")
+    version_from_env = auto_container.connection.check_output(
+        "echo $PIP_VERSION"
+    )
 
     assert f"pip {version_from_env}" in reported_version
 
@@ -110,9 +108,9 @@ def test_tox(auto_container):
 def test_pip_install_source_cryptography(auto_container_per_test):
     """Check that cryptography python module can be installed from source so that
     it is built against the SLE BCI FIPS enabled libopenssl."""
-    version = auto_container_per_test.connection.run_expect(
-        [0], "echo $PYTHON_VERSION"
-    ).stdout.strip()
+    version = auto_container_per_test.connection.check_output(
+        "echo $PYTHON_VERSION"
+    )
 
     if packaging.version.Version(version) < packaging.version.Version("3.8"):
         pytest.skip("cryptography tests only supported on >= 3.8")
@@ -240,10 +238,9 @@ def test_python_webserver_2(
     assert not container_per_test.connection.file(destdir + xfilename).exists
 
     # execution of the python module in the container
-    bci_python_wget = container_per_test.connection.run_expect(
-        [0],
+    bci_python_wget = container_per_test.connection.check_output(
         f"timeout --preserve-status 120s python3 {appdir + appl2} {url} {destdir}",
-    ).stdout
+    )
 
     # run the test in the container and check expected keyword from the module
     assert "PASS" in bci_python_wget
@@ -269,9 +266,7 @@ def test_tensorf(container_per_test):
     assert container_per_test.connection.file(bcdir + appdir + appl1).is_file
 
     # collect CPU flags of the system
-    cpuflg = container_per_test.connection.run_expect(
-        [0], "cat /proc/cpuinfo"
-    ).stdout
+    cpuflg = container_per_test.connection.file("/proc/cpuinfo").content_string
 
     # In precompiled Tensorflow library by default 'sse4' cpu flag expected
     assert "sse4" in cpuflg

--- a/tests/test_ruby.py
+++ b/tests/test_ruby.py
@@ -20,27 +20,21 @@ def test_ruby_version(auto_container):
     match the version of Ruby in the container.
 
     """
-    rb_ver = auto_container.connection.run_expect(
-        [0], "ruby -e 'puts RUBY_VERSION'"
-    ).stdout.strip()
+    rb_ver = auto_container.connection.check_output(
+        "ruby -e 'puts RUBY_VERSION'"
+    )
     assert (
-        auto_container.connection.run_expect(
-            [0], "echo $RUBY_VERSION"
-        ).stdout.strip()
-        == rb_ver
+        auto_container.connection.check_output("echo $RUBY_VERSION") == rb_ver
     )
 
-    assert auto_container.connection.run_expect(
-        [0], "echo $RUBY_MAJOR"
-    ).stdout.strip() == ".".join(rb_ver.split(".")[:-1])
+    assert auto_container.connection.check_output(
+        "echo $RUBY_MAJOR"
+    ) == ".".join(rb_ver.split(".")[:-1])
 
 
 def test_lang_set(auto_container):
     """Assert that the environment variable ``LANG`` is set to ``C.UTF-8``."""
-    assert (
-        auto_container.connection.run_expect([0], "echo $LANG").stdout.strip()
-        == "C.UTF-8"
-    )
+    assert auto_container.connection.check_output("echo $LANG") == "C.UTF-8"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_rust.py
+++ b/tests/test_rust.py
@@ -17,12 +17,8 @@ def test_rust_version(auto_container):
 
     """
     assert (
-        auto_container.connection.run_expect(
-            [0], "echo $RUST_VERSION"
-        ).stdout.strip()
-        == auto_container.connection.run_expect([0], "rustc --version")
-        .stdout.strip()
-        .split()[1]
+        auto_container.connection.check_output("echo $RUST_VERSION")
+        == auto_container.connection.check_output("rustc --version").split()[1]
     )
 
 
@@ -32,12 +28,8 @@ def test_cargo_version(auto_container):
 
     """
     assert (
-        auto_container.connection.run_expect(
-            [0], "echo $CARGO_VERSION"
-        ).stdout.strip()
-        == auto_container.connection.run_expect([0], "cargo --version")
-        .stdout.strip()
-        .split()[1]
+        auto_container.connection.check_output("echo $CARGO_VERSION")
+        == auto_container.connection.check_output("cargo --version").split()[1]
     )
 
 


### PR DESCRIPTION
check_output(..) is a shortcut for run_expect([0], ...).stdout