### PR TITLE
Restrict repository checks to the BCI repo

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -149,6 +149,13 @@ else:
     }[TARGET]
 
 
+BCI_REPO_NAME = "SLE_BCI"
+if OS_VERSION == "tumbleweed":
+    BCI_REPO_NAME = "repo-oss"
+if OS_VERSION == "basalt":
+    BCI_REPO_NAME = "repo-basalt"
+
+
 def create_container_version_mark(
     available_versions: Iterable[str],
 ) -> MarkDecorator:
@@ -181,7 +188,7 @@ if BCI_DEVEL_REPO is None:
     BCI_DEVEL_REPO = f"https://updates.suse.com/SUSE/Products/SLE-BCI/{OS_MAJOR_VERSION}-SP{OS_SP_VERSION}/{LOCALHOST.system_info.arch}/product/"
     _BCI_CONTAINERFILE = ""
 else:
-    _BCI_CONTAINERFILE = f"RUN sed -i 's|baseurl.*|baseurl={BCI_DEVEL_REPO}|' /etc/zypp/repos.d/SLE_BCI.repo"
+    _BCI_CONTAINERFILE = f"RUN sed -i 's|baseurl.*|baseurl={BCI_DEVEL_REPO}|' /etc/zypp/repos.d/{BCI_REPO_NAME}.repo"
 
 
 _IMAGE_TYPE_T = Literal["dockerfile", "kiwi"]
@@ -543,17 +550,14 @@ POSTGRESQL_CONTAINERS = [
 
 REPOCLOSURE_CONTAINER = DerivedContainer(
     base="registry.fedoraproject.org/fedora:latest",
-    containerfile=r"""RUN dnf -y install 'dnf-command(repoclosure)'
+    containerfile=rf"""RUN dnf -y install 'dnf-command(repoclosure)'
 RUN rm -f /etc/yum.repos.d/*repo
-RUN echo $'[SLE_BCI] \n\
-enabled=1 \n\
-name="SLE BCI" \n\
-autorefresh=0 \n\
-baseurl="""
-    + BCI_DEVEL_REPO
-    + r""" \n\
-priority=100' > /etc/yum.repos.d/SLE_BCI.repo
-""",
+RUN printf '[{BCI_REPO_NAME}]\n\
+enabled=1\n\
+name="SLE BCI"\n\
+autorefresh=0\n\
+baseurl={BCI_DEVEL_REPO}\n\
+priority=100\n' > /etc/yum.repos.d/{BCI_REPO_NAME}.repo""",
 )
 
 

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -14,6 +14,7 @@ from pytest_container import MultiStageBuild
 from pytest_container.container import ContainerData
 
 from bci_tester.data import ALL_CONTAINERS
+from bci_tester.data import BCI_REPO_NAME
 from bci_tester.data import BUSYBOX_CONTAINER
 from bci_tester.data import CONTAINERS_WITH_ZYPPER
 from bci_tester.data import INIT_CONTAINER
@@ -211,15 +212,10 @@ def test_zypper_dup_works(container_per_test: ContainerData) -> None:
     so we frequently get downgrades in this test. allow --allow-downgrade therefore
     but still test that there wouldn't be conflicts with what is available in SLE_BCI.
     """
-    repo_name = "SLE_BCI"
-    if OS_VERSION == "tumbleweed":
-        repo_name = "repo-oss"
-    if OS_VERSION == "basalt":
-        repo_name = "repo-basalt"
 
     container_per_test.connection.run_expect(
         [0],
-        f"timeout 5m zypper -n dup --from {repo_name} -l "
+        f"timeout 5m zypper -n dup --from {BCI_REPO_NAME} -l "
         "--no-allow-vendor-change --allow-downgrade --no-allow-arch-change",
     )
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -194,7 +194,7 @@ def test_package_installation(container_per_test, pkg):
     :command:`curl` and :command:`unzip`) can be installed. Additionally, try to
     install all packages from :py:const:`REPOCLOSURE_FALSE_POSITIVES`, ensuring
     that they are not accidentally not installable.
-
+    We additionally have to remove the ``container-suseconnect`` zypper service before running the test to ensure that no SLES repositories are added on registered hosts thereby skewing our results.
     """
 
     container_per_test.connection.check_output(


### PR DESCRIPTION
In case the host is registered, it would otherwise use the registered channels