### PR TITLE
Add more repoclosure false positives

### DIFF
--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -38,6 +38,8 @@ REPOCLOSURE_FALSE_POSITIVES = (
         [
             "qml-autoreqprov",
             "typelib-1_0-Gtk-4_0",
+            "python311-aiohttp",
+            "python311-libcst",
         ]
         if OS_SP_VERSION >= 4
         else []


### PR DESCRIPTION
The python311 stack has complex dependencies that dnf is not able to evaluate properly.