### PR TITLE
Fix node test container parametrize

### DIFF
--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -33,7 +33,7 @@ def test_node_version(auto_container):
                 build_command="npm ci && npm test",
             )
             if LOCALHOST.system_info.arch in ("x86_64",)
-            else (),
+            else None,
             GitRepositoryBuild(
                 repository_url="https://github.com/tj/commander.js.git",
                 build_command="npm ci && npm test && npm run lint",
@@ -69,6 +69,7 @@ def test_node_version(auto_container):
                 build_command="npm install && npm run unit",
             ),
         )
+        if pkg is not None
     ],
     indirect=["container_git_clone"],
 )


### PR DESCRIPTION
Don't use an empty tuple but a None object when building the test git repositories, to avoid using an empty tuple object with `to_pytest_param`.

This PR is a quickfix for e.g. https://openqa.suse.de/tests/12723318#step/_root_BCI-tests_node_docker/1