### PR TITLE
Add a specific login route for SP3 and SP4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -332,12 +332,17 @@ jobs:
 
       - name: Login to the registry if needed
         run: |
-          if [ "$TARGET" = "ibs-released" ]; then
-            echo $REGISTRY_LOGIN_PASSWORD | podman login -u $REGISTRY_LOGIN_USERNAME --password-stdin registry.suse.com
+          if [ "$OS_VERSION" = "15.3" ]; then
+            echo $REGISTRY_LOGIN_15SP3_PASSWORD | podman login -u $REGISTRY_LOGIN_15SP3_USERNAME --password-stdin registry.suse.com
+          fi
+          if [ "$OS_VERSION" = "15.4" ]; then
+            echo $REGISTRY_LOGIN_15SP4_PASSWORD | podman login -u $REGISTRY_LOGIN_15SP4_USERNAME --password-stdin registry.suse.com
           fi
         env:
-          REGISTRY_LOGIN_USERNAME: ${{ secrets.REGISTRY_LOGIN_USERNAME }}
-          REGISTRY_LOGIN_PASSWORD: ${{ secrets.REGISTRY_LOGIN_PASSWORD }}
+          REGISTRY_LOGIN_15SP3_USERNAME: ${{ secrets.REGISTRY_LOGIN_15SP3_USERNAME }}
+          REGISTRY_LOGIN_15SP3_PASSWORD: ${{ secrets.REGISTRY_LOGIN_15SP3_PASSWORD }}
+          REGISTRY_LOGIN_15SP4_USERNAME: ${{ secrets.REGISTRY_LOGIN_15SP4_USERNAME }}
+          REGISTRY_LOGIN_15SP4_PASSWORD: ${{ secrets.REGISTRY_LOGIN_15SP4_PASSWORD }}
           TARGET: ${{ matrix.testing_target != '' && matrix.testing_target || 'obs' }}
 
       - name: Add /etc/host entries


### PR DESCRIPTION
The repository credentials for LTSS are service pack specific, so we need to pick the ones related to the version. Also, we now login always which helps a bit with getting proper pull statistics.