### PR TITLE
Skip BCI repo specific tests on LTSS containers

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -44,6 +44,9 @@ ALLOWED_BASE_OS_VERSIONS = (
 # Allowed os versions for Language and Application containers
 ALLOWED_NONBASE_OS_VERSIONS = ("15.4", "15.5", "15.6", "tumbleweed")
 
+# Allowed os versions for SLE_BCI repo checks
+ALLOWED_BCI_REPO_OS_VERSIONS = ("15.5", "15.6", "tumbleweed")
+
 # Test Language and Application containers by default for these versions
 _DEFAULT_NONBASE_OS_VERSIONS = ("15.5", "15.6", "tumbleweed")
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -8,6 +8,7 @@ from typing import List
 import pytest
 from pytest_container.runtime import LOCALHOST
 
+from bci_tester.data import ALLOWED_BCI_REPO_OS_VERSIONS
 from bci_tester.data import BASE_CONTAINER
 from bci_tester.data import BCI_REPO_NAME
 from bci_tester.data import OS_SP_VERSION
@@ -191,6 +192,10 @@ def test_sle_bci_forbidden_packages(container_per_test):
     ), f"package_list must not contain any forbidden packages, but found {', '.join(forbidden_packages)}"
 
 
+@pytest.mark.skipif(
+    OS_VERSION not in ALLOWED_BCI_REPO_OS_VERSIONS,
+    reason=f"no included BCI repository - can't test",
+)
 @pytest.mark.parametrize(
     "pkg", ["git", "curl", "wget", "unzip"] + REPOCLOSURE_FALSE_POSITIVES
 )
@@ -208,6 +213,10 @@ def test_package_installation(container_per_test, pkg):
     )
 
 
+@pytest.mark.skipif(
+    OS_VERSION not in ALLOWED_BCI_REPO_OS_VERSIONS,
+    reason=f"no included BCI repository - can't test",
+)
 @pytest.mark.skipif(
     OS_VERSION == "tumbleweed", reason="No testing for openSUSE"
 )


### PR DESCRIPTION
They don't have a SLE_BCI repo anymore, so the tests can never pass