### PR TITLE
Revert "Add a specific login route for SP3 and SP4"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -330,15 +330,18 @@ jobs:
           -----END PGP PUBLIC KEY BLOCK-----
           EOF
 
-      - name: Login to the registry if needed
+      - name: Login to registry.suse.com as CI user
         run: |
-          if [ "$TARGET" = "ibs-released" ]; then
+          if [ "$CONTAINER_RUNTIME" = "DOCKER" ]; then
+            echo $REGISTRY_LOGIN_PASSWORD | docker login -u $REGISTRY_LOGIN_USERNAME --password-stdin registry.suse.com
+          fi
+          if [ "$CONTAINER_RUNTIME" = "PODMAN" ]; then
             echo $REGISTRY_LOGIN_PASSWORD | podman login -u $REGISTRY_LOGIN_USERNAME --password-stdin registry.suse.com
           fi
         env:
           REGISTRY_LOGIN_USERNAME: ${{ secrets.REGISTRY_LOGIN_USERNAME }}
           REGISTRY_LOGIN_PASSWORD: ${{ secrets.REGISTRY_LOGIN_PASSWORD }}
-          TARGET: ${{ matrix.testing_target != '' && matrix.testing_target || 'obs' }}
+          CONTAINER_RUNTIME: ${{ matrix.container_runtime }}
 
       - name: Add /etc/host entries
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -332,15 +332,12 @@ jobs:
 
       - name: Login to the registry if needed
         run: |
-          echo "logging in with 15.3 credentials"
-          echo $REGISTRY_LOGIN_15SP3_PASSWORD | podman login -u $REGISTRY_LOGIN_15SP3_USERNAME --password-stdin registry.suse.com/suse/ltss/sle15.3
-          echo "logging in with 15.4 credentials"
-          echo $REGISTRY_LOGIN_15SP4_PASSWORD | podman login -u $REGISTRY_LOGIN_15SP4_USERNAME --password-stdin registry.suse.com/suse/ltss/sle15.4
+          if [ "$TARGET" = "ibs-released" ]; then
+            echo $REGISTRY_LOGIN_PASSWORD | podman login -u $REGISTRY_LOGIN_USERNAME --password-stdin registry.suse.com
+          fi
         env:
-          REGISTRY_LOGIN_15SP3_USERNAME: ${{ secrets.REGISTRY_LOGIN_15SP3_USERNAME }}
-          REGISTRY_LOGIN_15SP3_PASSWORD: ${{ secrets.REGISTRY_LOGIN_15SP3_PASSWORD }}
-          REGISTRY_LOGIN_15SP4_USERNAME: ${{ secrets.REGISTRY_LOGIN_15SP4_USERNAME }}
-          REGISTRY_LOGIN_15SP4_PASSWORD: ${{ secrets.REGISTRY_LOGIN_15SP4_PASSWORD }}
+          REGISTRY_LOGIN_USERNAME: ${{ secrets.REGISTRY_LOGIN_USERNAME }}
+          REGISTRY_LOGIN_PASSWORD: ${{ secrets.REGISTRY_LOGIN_PASSWORD }}
           TARGET: ${{ matrix.testing_target != '' && matrix.testing_target || 'obs' }}
 
       - name: Add /etc/host entries


### PR DESCRIPTION
We have now globally working credentials. so we don't need to login twice.

This reverts commit e70e2f20db13590233d1457c6621c5ad9152f541.