### PR TITLE
Create the marks for default_repos for Base containers again

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -302,7 +302,9 @@ def create_BCI(
     # only try to grab the mark from the build tag for containers that are
     # available for this os version, otherwise we get bogus errors for missing
     # marks
-    if OS_VERSION in (available_versions or []):
+    if OS_VERSION in (
+        available_versions or list(_DEFAULT_NONBASE_OS_VERSIONS)
+    ):
         marks.append(pytest.mark.__getattr__(build_tag_base.replace(":", "_")))
 
     if OS_VERSION == "tumbleweed":

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -14,6 +14,7 @@ from pytest_container import MultiStageBuild
 from pytest_container.container import ContainerData
 
 from bci_tester.data import ALL_CONTAINERS
+from bci_tester.data import ALLOWED_BCI_REPO_OS_VERSIONS
 from bci_tester.data import BCI_REPO_NAME
 from bci_tester.data import BUSYBOX_CONTAINER
 from bci_tester.data import CONTAINERS_WITH_ZYPPER
@@ -216,13 +217,8 @@ def test_glibc_present(auto_container):
 
 
 @pytest.mark.skipif(
-    TARGET in ("ibs", "ibs-cr", "ibs-released")
-    and OS_VERSION in ("15.3", "15.4"),
+    OS_VERSION not in ALLOWED_BCI_REPO_OS_VERSIONS,
     reason="LTSS containers are known to be non-functional with BCI_repo ",
-)
-@pytest.mark.skipif(
-    OS_VERSION == "basalt",
-    reason="Basalt repos are known to be out of sync with IBS state",
 )
 @pytest.mark.parametrize(
     "container_per_test", CONTAINERS_WITH_ZYPPER, indirect=True


### PR DESCRIPTION
This is a regression from 967db993afe3e1349538e9fde8610324e319406e which broke BCI repository pipeline