### PR TITLE
Remove serde from the rust testsuite temporarily until we updated to

### DIFF
--- a/tests/test_rust.py
+++ b/tests/test_rust.py
@@ -71,10 +71,11 @@ def test_cargo_version(auto_container):
                 repository_url="https://github.com/unicode-rs/unicode-xid",
                 build_command="cargo build && cargo test",
             ),
-            GitRepositoryBuild(
-                repository_url="https://github.com/serde-rs/serde",
-                build_command="pushd serde && cargo build --features rc && cargo build --no-default-features && popd && pushd test_suite && cargo build && cargo test --features serde/derive,serde/rc",
-            ),
+            # no longer compatible with rust 1.73 which we unfortunately still ship :(
+            # GitRepositoryBuild(
+            #     repository_url="https://github.com/serde-rs/serde",
+            #     build_command="cargo build --features rc && cargo build --no-default-features && pushd test_suite && cargo build && cargo test --features serde/derive,serde/rc",
+            # ),
             GitRepositoryBuild(
                 repository_url="https://github.com/bitflags/bitflags",
                 build_command="cargo test --features example_generated",


### PR DESCRIPTION
rust 1.75