### PR TITLE
Test the MS rpm repo on all .Net container images, not just the SDK

### DIFF
--- a/tests/test_dotnet.py
+++ b/tests/test_dotnet.py
@@ -170,7 +170,7 @@ def test_dotnet_sdk_telemetry_deactivated(container_per_test):
 
 
 @pytest.mark.parametrize(
-    "container_per_test", DOTNET_SDK_CONTAINERS, indirect=True
+    "container_per_test", DOTNET_CONTAINERS, indirect=True
 )
 def test_microsoft_dotnet_repository(container_per_test):
     """Check that we have correctly added and configured the Microsoft .Net


### PR DESCRIPTION
We are adding the repository into the containers and hence we should be testing it as well.