### PR TITLE
Add 15.6 to the OpenSSL 3 list

### DIFF
--- a/bci_tester/fips.py
+++ b/bci_tester/fips.py
@@ -7,7 +7,7 @@ from bci_tester.data import OS_VERSION
 NONFIPS_DIGESTS = ("blake2b512", "blake2s256", "md5", "rmd160", "sm3")
 
 # OpenSSL 3.x in Tumbleweed dropped those as they're beyond deprecated
-if OS_VERSION not in ("basalt", "tumbleweed"):
+if OS_VERSION not in ("basalt", "tumbleweed", "15.6"):
     NONFIPS_DIGESTS += ("md4", "mdc2")
 
 #: FIPS compliant openssl digests

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -33,7 +33,7 @@ def test_base_size(auto_container, container_runtime):
     """
 
     #: size limits of the base container per arch in MiB
-    if OS_VERSION in ("basalt", "tumbleweed"):
+    if OS_VERSION in ("basalt", "tumbleweed", "15.6"):
         BASE_CONTAINER_MAX_SIZE: Dict[str, int] = {
             "x86_64": 135,
             "aarch64": 135,
@@ -70,7 +70,7 @@ def test_gost_digest_disable(auto_container):
     """Checks that the gost message digest is not known to openssl."""
     openssl_error_message = (
         "Invalid command 'gost'"
-        if OS_VERSION in ("basalt", "tumbleweed")
+        if OS_VERSION in ("basalt", "tumbleweed", "15.6")
         else "gost is not a known digest"
     )
     assert (
@@ -108,7 +108,7 @@ def test_all_openssl_hashes_known(auto_container):
     EXPECTED_DIGEST_LIST = ALL_DIGESTS
     # gost is not supported to generate digests, but it appears in:
     # openssl list --digest-commands
-    if OS_VERSION not in ("basalt", "tumbleweed"):
+    if OS_VERSION not in ("basalt", "tumbleweed", "15.6"):
         EXPECTED_DIGEST_LIST += ("gost",)
     assert len(hashes) == len(EXPECTED_DIGEST_LIST)
     assert set(hashes) == set(EXPECTED_DIGEST_LIST)


### PR DESCRIPTION
This fixes the failing BCI base 15.6 tests.