### PR TITLE
Increase the size a bit more for aarch64

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -52,7 +52,7 @@ def test_base_size(auto_container: ContainerData, container_runtime):
     if OS_VERSION in ("basalt", "tumbleweed", "15.6") or is_fips_ctr:
         BASE_CONTAINER_MAX_SIZE: Dict[str, int] = {
             "x86_64": 135,
-            "aarch64": 143,
+            "aarch64": 147,
             "ppc64le": 175,
             "s390x": 140,
         }


### PR DESCRIPTION
In this VR that fails https://openqa.suse.de/tests/13724362#step/_root_BCI-tests_base_/3 the size is 146 MiB