### PR TITLE
Add ecryptfs-utils to the repoclosure false positives for >= SP6

### DIFF
--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -46,8 +46,15 @@ REPOCLOSURE_FALSE_POSITIVES = (
         if OS_SP_VERSION >= 4
         else []
     )
-    # has a boolean dependency on NetworkManager
-    + (["jeos-firstboot"] if OS_SP_VERSION >= 6 else [])
+    + (
+        [  # has a boolean dependency on NetworkManager
+            "jeos-firstboot",
+            # has a boolean dependency on the kernel
+            "ecryptfs-utils",
+        ]
+        if OS_SP_VERSION >= 6
+        else []
+    )
     + (
         ["open-vm-tools"]
         if OS_SP_VERSION >= 5


### PR DESCRIPTION
ecryptfs-utils requires `(kmod(ecryptfs.ko) if kernel)` since SP6, but that cannot be resolved as we neither have the kernel nor `kmod(ecryptfs.ko)`