### PR TITLE
Increase the size of aarch64 image

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -52,7 +52,7 @@ def test_base_size(auto_container: ContainerData, container_runtime):
     if OS_VERSION in ("basalt", "tumbleweed", "15.6") or is_fips_ctr:
         BASE_CONTAINER_MAX_SIZE: Dict[str, int] = {
             "x86_64": 135,
-            "aarch64": 147,
+            "aarch64": 150,
             "ppc64le": 175,
             "s390x": 140,
         }


### PR DESCRIPTION
In the new build the VR for aarch64 are failing because the size increased again to 149 MiB. 

https://openqa.suse.de/tests/13764074#step/_root_BCI-tests_base_/4

https://openqa.suse.de/tests/13764080#step/_root_BCI-tests_base_/4

`Base container size is 149.0 MiB for aarch64 (expected 142..147 MiB)`