### PR TITLE
Avoid renames in the orphaned package test

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -286,7 +286,8 @@ def test_no_orphaned_packages(container_per_test: ContainerData) -> None:
 
     container_per_test.connection.check_output(
         f"timeout 5m zypper -n dup --from {BCI_REPO_NAME} -l "
-        "--no-allow-vendor-change --allow-downgrade --no-allow-arch-change"
+        "--no-allow-vendor-change --no-allow-name-change --no-allow-arch-change "
+        "--allow-downgrade "
     )
 
     searchresult = ET.fromstring(


### PR DESCRIPTION
The rust containers have found a new way to break the world. they have provide/obsoletes so the first time you run "zypper update", your handcrafted rust 1.75 container becomes a rust 1.77 container.

Catch this in the orphaned package check.