### PR TITLE
Skip rancher from building

### DIFF
--- a/tests/test_go.py
+++ b/tests/test_go.py
@@ -130,6 +130,7 @@ def test_build_generics_cache(
     )
 
 
+@pytest.mark.xfail(True, reason="Rancher build completely messed up")
 @pytest.mark.parametrize(
     "container",
     GOLANG_CONTAINERS,


### PR DESCRIPTION
the build is completely messed up, even going back to an older release no longer works. disable it for now