### PR TITLE
Restore minimal container size checking to previous values

### DIFF
--- a/tests/test_minimal.py
+++ b/tests/test_minimal.py
@@ -12,10 +12,10 @@ from bci_tester.data import OS_VERSION
 
 #: size limits of the minimal image per architecture in MiB
 SLE_MINIMAL_IMAGE_MAX_SIZE: Dict[str, int] = {
-    "x86_64": 50,
-    "aarch64": 52,
-    "s390x": 50,
-    "ppc64le": 60,
+    "x86_64": 49,
+    "aarch64": 51,
+    "s390x": 49,
+    "ppc64le": 59,
 }
 
 TW_MINIMAL_IMAGE_MAX_SIZE: Dict[str, int] = {
@@ -41,10 +41,6 @@ TW_MICRO_IMAGE_MAX_SIZE: Dict[str, int] = {
 }
 
 
-@pytest.mark.xfail(
-    OS_VERSION in ("15.6",),
-    reason="rpm has too many dependencies in SLE 15.5+",
-)
 @pytest.mark.parametrize("container", [MINIMAL_CONTAINER], indirect=True)
 def test_minimal_image_size(container, container_runtime):
     """Check that the size of the minimal container is below the limits specified in


### PR DESCRIPTION
rpm regression was fixed, libpcre1 leftover was removed. Things should be good again.

This reverts commit a784749368dd9639036b1137e82d03f4d1633516.