### PR TITLE
Increase the minimal image size per architecture

### DIFF
--- a/tests/test_minimal.py
+++ b/tests/test_minimal.py
@@ -12,10 +12,10 @@ from bci_tester.data import OS_VERSION
 
 #: size limits of the minimal image per architecture in MiB
 SLE_MINIMAL_IMAGE_MAX_SIZE: Dict[str, int] = {
-    "x86_64": 49,
-    "aarch64": 51,
-    "s390x": 49,
-    "ppc64le": 59,
+    "x86_64": 53,
+    "aarch64": 57,
+    "s390x": 53,
+    "ppc64le": 63,
 }
 
 TW_MINIMAL_IMAGE_MAX_SIZE: Dict[str, int] = {


### PR DESCRIPTION
VRs in openQA are failing for the bci-sp6 minimal image because of the size increase on all architectures: [aarch64](https://openqa.suse.de/tests/14011894#step/_root_BCI-tests_minimal_/1), [ppc64le](https://openqa.suse.de/tests/14011972#step/_root_BCI-tests_minimal_/1), [s390x](https://openqa.suse.de/tests/14011952), [x86_64](https://openqa.suse.de/tests/14014636#step/_root_BCI-tests_minimal_/1)
So, this PR bumps the size for the minimal image test.  