### PR TITLE
accept larger size for 15.4 LTSS also

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -50,7 +50,10 @@ def test_base_size(auto_container: ContainerData, container_runtime):
 
     #: size limits of the base container per arch in MiB
     # 15.5/15.6 are hopefully only temporary large due to PED-5014
-    if OS_VERSION in ("basalt", "tumbleweed", "15.5", "15.6") or is_fips_ctr:
+    if (
+        OS_VERSION in ("basalt", "tumbleweed", "15.4", "15.5", "15.6")
+        or is_fips_ctr
+    ):
         BASE_CONTAINER_MAX_SIZE: Dict[str, int] = {
             "x86_64": 139,
             "aarch64": 160,


### PR DESCRIPTION
The update has also been introduced in the SP4 LTSS image, which causes many failures in [openQA](https://openqa.suse.de/tests/overview?result=failed&result=incomplete&result=timeout_exceeded&distri=sle&version=15-SP4&build=3.25_sles15-ltss-image&groupid=443). It is related to https://github.com/SUSE/BCI-tests/pull/458.  

VRs: https://openqa.suse.de/tests/14115056, https://openqa.suse.de/tests/14115057