### PR TITLE
Run tests using the chat command /run_tests toxenvs=mariadb,nginx

### DIFF
--- a/.github/workflows/command-dispatch.yml
+++ b/.github/workflows/command-dispatch.yml
@@ -1,0 +1,18 @@
+---
+name: Slash Command Dispatch
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  dispatch-command:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v4
+        with:
+          token: ${{ secrets.PAT }}
+          commands: |
+            help
+            run_tests
+          issue-type: pull-request
+          permission: none

--- a/.github/workflows/help-command.yml
+++ b/.github/workflows/help-command.yml
@@ -1,0 +1,20 @@
+---
+name: help-command
+on:
+  repository_dispatch:
+    types: [help-command]
+jobs:
+  help:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.PAT }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          body: |
+            > Command | Description
+            > --- | ---
+            > /help | Print this message
+            > /run_tests toxenvs=$toxenvs | Runs the specified tox environments, the environments have to be specified separated by commas

--- a/.github/workflows/run_tests-command.yml
+++ b/.github/workflows/run_tests-command.yml
@@ -1,128 +1,47 @@
 ---
-name: CI
-
+name: Run Tests Command
 on:
-  schedule:
-    - cron: '44 4 */2 * *'
-  pull_request:
   repository_dispatch:
-
-concurrency:
-  group: integration-tests-${{ github.ref_name }}
-  cancel-in-progress: true
+    types: [run_tests-command]
 
 jobs:
-  format:
-    name: Ensure code is black formatted
+  gentestmatrix:
+    name: Generate test matrix
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.setmatrix.outputs.matrix }}
     steps:
-      - name: checkout source code
-        uses: actions/checkout@v4
+        # jo is used only to generate matrix using json easily
       - name: Install necessary software
+        run: sudo apt update && sudo apt install jo
+      - id: setmatrix
         run: |
-          set -e
-          sudo apt update
-          sudo apt -y install jo tox
-      - name: Test formatting with black
-        run: tox -e format -- --check
+          stringified_matrix=$(echo "${{ github.event.client_payload.slash_command.args.named.user }}" | sed 's|,|\n|g' | jo -a)
+          echo "matrix=$stringified_matrix" >> $GITHUB_OUTPUT
 
-  unit-tests:
-    name: Unit tests
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python_version: ["3.6", "3.9", "3.10", "3.11"]
-    container:
-      image: registry.suse.com/bci/python:${{ matrix.python_version }}
-    steps:
-      - name: checkout source code
-        uses: actions/checkout@v4
-      - name: Install tox
-        run: |
-          python3 --version
-          python3 -m ensurepip
-          python3 -m pip install tox
-      - run: 'tox -e py$(echo $PY_VER | tr -d . )-unit -- -n auto'
-        env:
-          SETUPTOOLS_SCM_PRETEND_VERSION: 1.2.3
-          PY_VER: ${{ matrix.python_version }}
+      - name: generate the url to this workflow run
+        run: echo "run_url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_ENV
 
-  documentation:
-    name: Build documentation
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Add a link to the error to the original comment on failure
+        if: ${{ failure() || cancelled() }}
+        uses: peter-evans/create-or-update-comment@v4
         with:
-          python-version: '3.x'
-      - name: Install tox
-        run: sudo apt update && sudo apt install tox
-      - run: tox -e doc
-
-  lint:
-    name: Lint source code
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-      - name: Install tox
-        run: sudo apt update && sudo apt install tox
-      - run: tox -e lint
+          token: ${{ secrets.PAT }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          body: Your tests are running in the following [workflow run](${{ env.run_url }})
 
   test-containers:
     name: tox
     runs-on: ubuntu-latest
+    needs: gentestmatrix
     strategy:
       fail-fast: false
       matrix:
-        toxenv:
-          - repository
-          - metadata
-          - build
-          - all
-          - multistage
+        toxenv: ${{fromJson(needs.gentestmatrix.outputs.matrix)}}
         os_version:
           - 15.5
           - 15.6
           - "tumbleweed"
-        include:
-          - toxenv: repository
-            testing_target: ibs-released
-            os_version: 15.5
-          - toxenv: all
-            testing_target: ibs-released
-            os_version: 15.3
-          - toxenv: base
-            testing_target: ibs-released
-            os_version: 15.3
-          - toxenv: all
-            testing_target: ibs-released
-            os_version: 15.4
-          - toxenv: base
-            testing_target: ibs-released
-            os_version: 15.4
-          - toxenv: metadata
-            testing_target: ibs-released
-            os_version: 15.4
-          - toxenv: all
-            os_version: 15.3
-          - toxenv: base
-            os_version: 15.3
-          - toxenv: build
-            os_version: 15.3
-          - toxenv: metadata
-            os_version: 15.3
-          - toxenv: all
-            os_version: 15.4
-          - toxenv: base
-            os_version: 15.4
-          - toxenv: build
-            os_version: 15.4
-          - toxenv: metadata
-            os_version: 15.4
 
     steps:
       - name: Clean up disk space to maximize available space


### PR DESCRIPTION
This should more or less allow us to run the BCI tests via a chatops command:

```
/run_tests toxevns=mariadb,nginx,openjdk,tomcat
```

I've made only the base set of tests run on each PR and the rest be triggered by a chat command. Unfortunately, we are now in a bit of an awkward spot: to test this, we need to merge this, as otherwise the `repository_dispatch` event is not sent & handled.

Also, this currently breaks our nightly CI: it will only run the base set of tests and not all of them