### PR TITLE
Add zypper to orphaned packages

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -334,7 +334,7 @@ def test_no_downgrade_on_install(container: ContainerData) -> None:
     ),
     indirect=True,
 )
-def test_no_orphaned_packages(container_per_test: ContainerData) -> None:
+def test_no_orphaned_packages(container_per_test: ContainerData, host) -> None:
     """Check that containers do not contain any package that isn't also
     available via repositories.
     """
@@ -369,6 +369,11 @@ def test_no_orphaned_packages(container_per_test: ContainerData) -> None:
         "sle-module-python3-release",
         "sle-module-server-applications-release",
     }
+    if (
+        host.system_info.type == "linux"
+        and host.system_info.distribution != "sles"
+    ):
+        known_orphaned_packages.add("zypper")
     assert not orphaned_packages.difference(known_orphaned_packages)
 
 


### PR DESCRIPTION
On non-SLES host, starting with the 15-SP6 image zypper appears as orphaned package.

* Related failures: [15-SP6 job group](https://openqa.suse.de/tests/overview?version=15-SP6&build=45.10&distri=sle&groupid=476) | [No orphans on 15-SP5 host](https://openqa.suse.de/tests/14124119#step/_root_BCI-tests_all_/11) | [Orphaned zypper on e.g. Leap 15.5](https://openqa.suse.de/tests/14124108#step/_root_BCI-tests_all_/12)