### PR TITLE
Spack only available for x86_64 and aarch64

### DIFF
--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -53,10 +53,16 @@ REPOCLOSURE_FALSE_POSITIVES = (
             "ecryptfs-utils",
             # has a boolean dependency on xwayland
             "at-spi2-core",
-            # has a boolean dependency on hwloc which is not part of SLE
-            "spack",
         ]
         if OS_SP_VERSION >= 6
+        else []
+    )
+    + (  # has a boolean dependency on hwloc which is not part of SLE
+        ["spack"]
+        if (
+            OS_SP_VERSION >= 6
+            and LOCALHOST.system_info.arch in ("aarch64", "x86_64")
+        )
         else []
     )
     + (  # has a boolean dependency on the kernel && only in x86_64


### PR DESCRIPTION
Spack is only available on x86_64 and aarch64.
Failing VR: https://openqa.suse.de/tests/14128383
Passing VR: https://openqa.suse.de/tests/14128446
Ref: https://build.opensuse.org/projects/openSUSE:Factory/packages/spack/files/spack.spec?expand=1