### PR TITLE
Workaround cassandra unpacking issues on tumbleweed in old container

### DIFF
--- a/tests/test_php.py
+++ b/tests/test_php.py
@@ -51,7 +51,7 @@ RUN set -e; zypper -n in $PHPIZE_DEPS oniguruma-devel libicu-devel gcc-c++ php8-
 RUN set -euo pipefail; \
     zypper -n in tar; \
     curl -sfOL "https://releases.wikimedia.org/mediawiki/${MEDIAWIKI_MAJOR_VERSION}/mediawiki-${MEDIAWIKI_VERSION}.tar.gz"; \
-    tar xvzf "mediawiki-${MEDIAWIKI_VERSION}.tar.gz"; \
+    tar -xf "mediawiki-${MEDIAWIKI_VERSION}.tar.gz"; \
     rm "mediawiki-${MEDIAWIKI_VERSION}.tar.gz"; \
     pushd "mediawiki-${MEDIAWIKI_VERSION}/"; mv * ..; popd; rmdir "mediawiki-${MEDIAWIKI_VERSION}"; \
     php maintenance/install.php --dbname mediawiki.db --dbtype sqlite --pass insecureAndAtLeast10CharsLong --scriptpath="" --server="http://localhost" test-wiki geeko; \


### PR DESCRIPTION
runtimes

Tumbleweed's tar is apparently leveraging some new syscalls that are blocked on old container runtimes like in the GitHub actions environment. So working around that by adding --no-same-permissions --no-same-owner

Also some small cleanup of the code.