### PR TITLE
Explicitly install libsolv-tools when we use it

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -262,7 +262,7 @@ def test_no_downgrade_on_install(container: ContainerData) -> None:
 
     conn = container.connection
 
-    conn.run_expect([0], "timeout 2m zypper ref")
+    conn.run_expect([0], "timeout 2m zypper ref && zypper -n in libsolv-tools")
 
     conn.check_output(
         "dumpsolv -j /var/cache/zypp/solv/@System/solv > /solv/system"


### PR DESCRIPTION
libsolv-tools is no longer part of the default installed packages, so we need to pull it in for the test