### PR TITLE
WIP: add minimal smoke test for postfix container image

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -332,7 +332,7 @@ def create_BCI(
         marks.append(pytest.mark.__getattr__(build_tag_base.replace(":", "_")))
 
     if OS_VERSION == "tumbleweed":
-        if bci_type == ImageType.APPLICATION:
+        if bci_type in (ImageType.APPLICATION, ImageType.SAC_APPLICATION):
             baseurl = (
                 f"{BASEURL}/{_get_repository_name(image_type)}{build_tag}"
             )
@@ -680,6 +680,20 @@ MARIADB_CLIENT_CONTAINERS = [
     for mariadb_client_ver, os_versions in _MARIADB_VERSION_OS_MATRIX
 ]
 
+POSTFIX_CONTAINERS = [
+    create_BCI(
+        build_tag=f"{SAC_CONTAINER_PREFIX}/postfix:{postfix_ver}",
+        bci_type=ImageType.SAC_APPLICATION,
+        available_versions=os_versions,
+        forwarded_ports=[PortForwarding(container_port=25)],
+        extra_environment_variables={"SERVER_HOSTNAME": "localhost"},
+    )
+    for postfix_ver, os_versions in (
+        (3.8, ["15.6"]),
+        (3.9, ["tumbleweed"]),
+    )
+]
+
 POSTGRES_PASSWORD = "n0ts3cr3t"
 
 POSTGRESQL_CONTAINERS = [
@@ -868,6 +882,7 @@ CONTAINERS_WITH_ZYPPER = (
     + NODEJS_CONTAINERS
     + OPENJDK_CONTAINERS
     + PCP_CONTAINERS
+    + POSTFIX_CONTAINERS
     + POSTGRESQL_CONTAINERS
     + PROMETHEUS_CONTAINERS
     + PYTHON_CONTAINERS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,8 @@ markers = [
     'php_8',
     'php-apache_8',
     'php-fpm_8',
+    'postfix_3.8',
+    'postfix_3.9',
     'postgres_14',
     'postgres_15',
     'postgres_16',

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -33,6 +33,7 @@ from bci_tester.data import OS_PRETTY_NAME
 from bci_tester.data import OS_VERSION
 from bci_tester.data import OS_VERSION_ID
 from bci_tester.data import PCP_CONTAINERS
+from bci_tester.data import POSTFIX_CONTAINERS
 
 CONTAINER_IMAGES = ALL_CONTAINERS
 
@@ -384,18 +385,25 @@ def test_zypper_verify_passes(container: ContainerData) -> None:
 
 # PCP_CONTAINERS: uses systemd for starting multiple services
 # KIWI_CONTAINERS: pulls lvm2 which pulls systemd
+# POSTFIX_CONTAINERS (SP6): pulls rsyslog which pulls systemd
 @pytest.mark.parametrize(
     "container",
     [
         c
         for c in ALL_CONTAINERS
-        if (c not in PCP_CONTAINERS + [INIT_CONTAINER] + KIWI_CONTAINERS)
+        if (
+            c
+            not in PCP_CONTAINERS
+            + [INIT_CONTAINER]
+            + KIWI_CONTAINERS
+            + (POSTFIX_CONTAINERS if OS_VERSION != "tumbleweed" else [])
+        )
     ],
     indirect=True,
 )
 def test_systemd_not_installed_in_all_containers_except_init(container):
     """Ensure that systemd is not present in all containers besides the init
-    and pcp containers.
+    pcp, and postfix containers.
 
     """
     assert not container.connection.exists("systemctl")

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -74,6 +74,7 @@ from bci_tester.data import PCP_CONTAINERS
 from bci_tester.data import PHP_8_APACHE
 from bci_tester.data import PHP_8_CLI
 from bci_tester.data import PHP_8_FPM
+from bci_tester.data import POSTFIX_CONTAINERS
 from bci_tester.data import POSTGRESQL_CONTAINERS
 from bci_tester.data import PROMETHEUS_CONTAINERS
 from bci_tester.data import PYTHON36_CONTAINER
@@ -208,6 +209,10 @@ IMAGES_AND_NAMES: List[ParameterSet] = [
             ImageType.APPLICATION,
         )
         for mariab_client_container in MARIADB_CLIENT_CONTAINERS
+    ]
+    + [
+        (postfix_container, "postfix", ImageType.SAC_APPLICATION)
+        for postfix_container in POSTFIX_CONTAINERS
     ]
     + [
         (pg_container, "postgres", ImageType.APPLICATION)

--- a/tests/test_postfix.py
+++ b/tests/test_postfix.py
@@ -1,0 +1,387 @@
+"""This module contains the tests for the postfix container, the image with postfix, sendmail and mailq pre-installed."""
+
+import pytest
+from pytest_container import DerivedContainer
+from pytest_container import container_and_marks_from_pytest_param
+from pytest_container.container import ContainerData
+from pytest_container.container import ImageFormat
+
+from bci_tester.data import OS_VERSION
+from bci_tester.data import POSTFIX_CONTAINERS
+
+CONTAINER_IMAGES = POSTFIX_CONTAINERS
+
+POSTFIX_WITH_LOGGING_ENABLED = []
+POSTFIX_WITH_MAILHOG = []
+POSTFIX_WITH_VIRTUAL_MBOX_ENABLED = []
+POSTFIX_WITH_LDAP_ENABLED = []
+
+
+CONTAINERFILE_POSTFIX_WITH_LOGGING_ENABLED = """
+RUN postconf maillog_file=/var/log/postfix.log
+RUN postconf maillog_file_permissions=0644
+HEALTHCHECK --interval=5s --timeout=10s --start-period=30s --retries=3 \
+        CMD postfix status
+"""
+
+
+CONTAINERFILE_POSTFIX_WITH_MAILHOG = """
+ENV MAILHOG_VERSION="v1.0.1"
+RUN set -euo pipefail; \
+    curl -L -o /usr/local/bin/mailhog https://github.com/mailhog/MailHog/releases/download/${MAILHOG_VERSION}/MailHog_linux_amd64; \
+    chmod +x /usr/local/bin/mailhog
+EXPOSE 1025 8025
+HEALTHCHECK --interval=5s --timeout=10s --start-period=30s --retries=3 \
+        CMD postfix status
+"""
+
+
+CONTAINERFILE_POSTFIX_WITH_LDAP_ENABLED = """
+RUN set -euo pipefail; \
+zypper -n in --no-recommends git find openldap2 openldap2-client; \
+zypper -n clean; \
+rm -rf /var/log/{lastlog,tallylog,zypper.log,zypp/history,YaST2}
+
+# TODO: move postfix & openldap container files to bci-dockerfile-generator
+RUN git clone https://github.com/thkukuk/containers-mailserver.git && \
+    cd containers-mailserver/openldap && \
+    cp -r ldif /entrypoint/ && \
+    cp slapd.init.ldif /entrypoint/ && \
+    cp entrypoint.sh /entrypoint/openldap-entrypoint.sh
+
+RUN FILE="/entrypoint/openldap-entrypoint.sh" && \
+    for cmd in \
+        's|-h "$LDAP_URL $LDAPS_URL $LDAPI_URL" ${SLAPD_SLP_REG}|-h "$LDAP_URL $LDAPS_URL $LDAPI_URL" ${SLAPD_SLP_REG} > /var/log/slapd.log 2>\\&1 \\&|' \
+        's|exec /usr/sbin/slapd -d "${SLAPD_LOG_LEVEL}" -u ldap -g ldap|exec nohup /usr/sbin/slapd -d "${SLAPD_LOG_LEVEL}" -u ldap -g ldap|' \
+        's|ldapadd -c -Y EXTERNAL -Q -H ldapi:/// -f /etc/openldap/schema/ppolicy.ldif||' \
+    ; do \
+        sed -i "$cmd" "$FILE"; \
+    done
+
+RUN echo 'dn: uid=user1,ou=mail,dc=example,dc=com' > /entrypoint/ldif/examples/example-user.ldif && \
+    echo 'cn: user1' >> /entrypoint/ldif/examples/example-user.ldif && \
+    echo 'gidnumber: 20001' >> /entrypoint/ldif/examples/example-user.ldif && \
+    echo 'homedirectory: /home/mail/user1' >> /entrypoint/ldif/examples/example-user.ldif && \
+    echo 'mailacceptinggeneralid: user1@example.com' >> /entrypoint/ldif/examples/example-user.ldif && \
+    echo 'maildrop: user1@mail.example.com' >> /entrypoint/ldif/examples/example-user.ldif && \
+    echo 'objectclass: account' >> /entrypoint/ldif/examples/example-user.ldif && \
+    echo 'objectclass: posixAccount' >> /entrypoint/ldif/examples/example-user.ldif && \
+    echo 'objectclass: postfixUser' >> /entrypoint/ldif/examples/example-user.ldif && \
+    echo 'objectclass: top' >> /entrypoint/ldif/examples/example-user.ldif && \
+    echo 'uid: user1' >> /entrypoint/ldif/examples/example-user.ldif && \
+    echo 'uidnumber: 20001' >> /entrypoint/ldif/examples/example-user.ldif && \
+    echo 'userpassword: user1' >> /entrypoint/ldif/examples/example-user.ldif && \
+    echo '' >> /entrypoint/ldif/examples/example-user.ldif && \
+    echo 'dn: uid=user2,ou=mail,dc=example,dc=com' >> /entrypoint/ldif/examples/example-user.ldif && \
+    echo 'cn: user2' >> /entrypoint/ldif/examples/example-user.ldif && \
+    echo 'gidnumber: 20002' >> /entrypoint/ldif/examples/example-user.ldif && \
+    echo 'homedirectory: /home/mail/user2' >> /entrypoint/ldif/examples/example-user.ldif && \
+    echo 'mailacceptinggeneralid: user2@example.com' >> /entrypoint/ldif/examples/example-user.ldif && \
+    echo 'maildrop: user2@mail.example.com' >> /entrypoint/ldif/examples/example-user.ldif && \
+    echo 'objectclass: account' >> /entrypoint/ldif/examples/example-user.ldif && \
+    echo 'objectclass: posixAccount' >> /entrypoint/ldif/examples/example-user.ldif && \
+    echo 'objectclass: postfixUser' >> /entrypoint/ldif/examples/example-user.ldif && \
+    echo 'objectclass: top' >> /entrypoint/ldif/examples/example-user.ldif && \
+    echo 'uid: user2' >> /entrypoint/ldif/examples/example-user.ldif && \
+    echo 'uidnumber: 20002' >> /entrypoint/ldif/examples/example-user.ldif && \
+    echo 'userpassword: user2' >> /entrypoint/ldif/examples/example-user.ldif
+
+HEALTHCHECK --interval=5s --timeout=10s --start-period=30s --retries=3 \
+        CMD postfix status
+"""
+
+
+for postfix_ctr in POSTFIX_CONTAINERS:
+    ctr, marks = container_and_marks_from_pytest_param(postfix_ctr)
+    POSTFIX_WITH_LOGGING_ENABLED.append(
+        pytest.param(
+            DerivedContainer(
+                base=ctr,
+                forwarded_ports=ctr.forwarded_ports,
+                containerfile=CONTAINERFILE_POSTFIX_WITH_LOGGING_ENABLED,
+                extra_environment_variables=ctr.extra_environment_variables,
+                image_format=ImageFormat.DOCKER,
+            ),
+            marks=marks,
+        )
+    )
+
+
+for postfix_ctr in POSTFIX_WITH_LOGGING_ENABLED:
+    ctr, marks = container_and_marks_from_pytest_param(postfix_ctr)
+    POSTFIX_WITH_MAILHOG.append(
+        pytest.param(
+            DerivedContainer(
+                base=ctr,
+                forwarded_ports=ctr.forwarded_ports,
+                containerfile=CONTAINERFILE_POSTFIX_WITH_MAILHOG,
+                extra_environment_variables={
+                    "SERVER_HOSTNAME": "localhost",
+                    "SMTP_RELAYHOST": "localhost",  # pointing to mailhog running locally
+                    "SMTP_PORT": "1025",
+                },
+                image_format=ImageFormat.DOCKER,
+            ),
+            marks=marks,
+        )
+    )
+
+
+for postfix_ctr in POSTFIX_WITH_MAILHOG:
+    ctr, marks = container_and_marks_from_pytest_param(postfix_ctr)
+    POSTFIX_WITH_VIRTUAL_MBOX_ENABLED.append(
+        pytest.param(
+            DerivedContainer(
+                base=ctr,
+                forwarded_ports=ctr.forwarded_ports,
+                containerfile=CONTAINERFILE_POSTFIX_WITH_MAILHOG,
+                extra_environment_variables={
+                    "SERVER_HOSTNAME": "localhost",
+                    "SMTP_RELAYHOST": "localhost",  # pointing to mailhog running locally
+                    "SMTP_PORT": "1025",
+                    "VIRTUAL_MBOX": "1",
+                    "VMAIL_UID": "5000",
+                    "VIRTUAL_DOMAINS": "example.com example1.com",
+                    "VIRTUAL_USERS": "user1@example.com user2@example.com user@example1.com",
+                },
+                image_format=ImageFormat.DOCKER,
+            ),
+            marks=marks,
+        )
+    )
+
+
+for postfix_ctr in POSTFIX_WITH_VIRTUAL_MBOX_ENABLED:
+    ctr, marks = container_and_marks_from_pytest_param(postfix_ctr)
+    POSTFIX_WITH_LDAP_ENABLED.append(
+        pytest.param(
+            DerivedContainer(
+                base=ctr,
+                forwarded_ports=ctr.forwarded_ports,
+                containerfile=CONTAINERFILE_POSTFIX_WITH_LDAP_ENABLED,
+                extra_environment_variables={
+                    "SERVER_HOSTNAME": "localhost",
+                    "SMTP_RELAYHOST": "localhost",  # pointing to mailhog running locally
+                    "SMTP_PORT": "1025",
+                    "VIRTUAL_MBOX": "1",
+                    "VMAIL_UID": "5000",
+                    "USE_LDAP": "1",
+                    "LDAP_BASE_DN": "dc=example,dc=com",
+                    "LDAP_BIND_DN": "cn=admin,dc=example,dc=com",
+                    "LDAP_BIND_PASSWORD": "admin",
+                    "LDAP_USE_TLS": "0",
+                    "LDAP_TLS": "0",
+                    "LDAP_DOMAIN": "example.com",
+                    "LDAP_ADMIN_PASSWORD": "admin",
+                    "LDAP_CONFIG_PASSWORD": "config",
+                    "SETUP_FOR_MAILSERVER": "1",
+                    "MAIL_ACCOUNT_READER_PASSWORD": "admin",
+                    "LDAP_SERVER_URL": "ldap://localhost",
+                },
+                image_format=ImageFormat.DOCKER,
+            ),
+            marks=marks,
+        )
+    )
+
+
+def test_postfix_status(auto_container):
+    """check if Postfix service is running inside the container"""
+
+    # verify PID 1 process is ENTRYPOINT - `/bin/bash /entrypoint/entrypoint.sh postfix start`
+    assert (
+        "/bin/bash /entrypoint/entrypoint.sh postfix start"
+        in auto_container.connection.check_output(
+            "ps -eo pid,cmd | grep '^ *1 ' | sed 's/^ *1 //'"
+        )
+    )
+
+    assert (
+        "the Postfix mail system is running"
+        in auto_container.connection.check_output("postfix status 2>&1")
+    )
+
+
+@pytest.mark.parametrize(
+    "container_per_test", POSTFIX_WITH_LOGGING_ENABLED, indirect=True
+)
+def test_postfix_send_email_delivered(
+    container_per_test: ContainerData,
+) -> None:
+    """test sending an email successfully to localhost, using Postfix container"""
+
+    assert container_per_test.connection.file("/var/log/postfix.log").exists
+
+    sendmail_cmd = 'echo "Subject: Test Email\n\nThis is a test email body." | sendmail -v root@localhost'
+    container_per_test.connection.check_output(sendmail_cmd)
+
+    assert "Mail queue is empty" in container_per_test.connection.check_output(
+        "sleep 10; mailq"
+    )
+
+    log = container_per_test.connection.file(
+        "/var/log/postfix.log"
+    ).content_string
+    for output in [
+        "from=<root@localhost>",
+        "dsn=2.0.0",
+        "status=sent (delivered to mailbox)",
+        "relay=local",
+    ]:
+        assert output in log
+
+
+@pytest.mark.parametrize(
+    "container_per_test", POSTFIX_WITH_LOGGING_ENABLED, indirect=True
+)
+def test_postfix_send_email_failed(
+    container_per_test: ContainerData,
+) -> None:
+    """send a test email using the Postfix container, which fails"""
+
+    sendmail_cmd = 'echo "Subject: Test Email\n\nThis is a test email body." | sendmail -f user1@example.com user2@example.com'
+    container_per_test.connection.check_output(sendmail_cmd)
+
+    assert "Mail queue is empty" in container_per_test.connection.check_output(
+        "sleep 10; mailq"
+    )
+
+    log = container_per_test.connection.file(
+        "/var/log/postfix.log"
+    ).content_string
+    for output in [
+        "to=<user1@example.com>",
+        "dsn=5.1.0",
+        "status=bounced (Domain example.com does not accept mail (nullMX))",
+        "relay=none",
+    ]:
+        assert output in log
+
+
+@pytest.mark.parametrize(
+    "container_per_test", POSTFIX_WITH_MAILHOG, indirect=True
+)
+def test_postfix_relay_email_to_mailhog(
+    container_per_test: ContainerData,
+) -> None:
+    """test relaying an email successfully to SMTP_RELAYHOST, using Postfix container"""
+
+    container_per_test.connection.check_output(
+        "nohup /usr/local/bin/mailhog > /dev/null 2>&1 &"
+    )
+
+    sendmail_cmd = 'echo "Subject: Test Email\n\nThis is a test email body." | sendmail -f user1@example.com user2@example.com'
+    container_per_test.connection.check_output(sendmail_cmd)
+
+    assert "Mail queue is empty" in container_per_test.connection.check_output(
+        "sleep 10; mailq"
+    )
+
+    log = container_per_test.connection.file(
+        "/var/log/postfix.log"
+    ).content_string
+    for output in [
+        "from=<user1@example.com>",
+        "to=<user2@example.com>",
+        "relay=localhost[127.0.0.1]:1025",
+        "dsn=2.0.0",
+        "status=sent (250 Ok: queued as ",
+        "=@mailhog.example)",
+    ]:
+        assert output in log
+
+
+@pytest.mark.parametrize(
+    "container_per_test", POSTFIX_WITH_VIRTUAL_MBOX_ENABLED, indirect=True
+)
+def test_postfix_send_email_delivered_to_virtual_mbox(
+    container_per_test: ContainerData,
+) -> None:
+    """test sending an email successfully to virtual mailbox, using Postfix container"""
+
+    container_per_test.connection.check_output(
+        "chown -R vmail:vmail /var/spool/vmail/"
+    )
+    container_per_test.connection.check_output(
+        "nohup /usr/local/bin/mailhog > /dev/null 2>&1 &"
+    )
+
+    sendmail_cmd = 'echo "Subject: Test Email\n\nThis is a test email body." | sendmail -f user1@example.com user2@example.com'
+    container_per_test.connection.check_output(sendmail_cmd)
+
+    assert "Mail queue is empty" in container_per_test.connection.check_output(
+        "sleep 10; mailq"
+    )
+
+    log = container_per_test.connection.file(
+        "/var/log/postfix.log"
+    ).content_string
+    for output in [
+        "from=<user1@example.com>",
+        "to=<user2@example.com>",
+        "relay=virtual",
+        "dsn=2.0.0",
+        "status=sent (delivered to maildir)",
+    ]:
+        assert output in log
+
+    assert container_per_test.connection.file(
+        "/var/spool/vmail/example.com/user2"
+    ).exists
+
+
+@pytest.mark.skipif(
+    OS_VERSION != "tumbleweed",
+    reason="openldap2 package only available on Tumbleweed (in the main system)",
+)
+@pytest.mark.parametrize(
+    "container_per_test", POSTFIX_WITH_LDAP_ENABLED, indirect=True
+)
+def test_postfix_with_ldap_and_email_delivered(
+    container_per_test: ContainerData,
+) -> None:
+    """test relaying an email successfully with ldap lookup, using Postfix container"""
+
+    container_per_test.connection.check_output(
+        "nohup /usr/local/bin/mailhog > /dev/null 2>&1 &"
+    )
+
+    container_per_test.connection.check_output(
+        "/entrypoint/openldap-entrypoint.sh /usr/sbin/slapd"
+    )
+    assert container_per_test.connection.socket(
+        "tcp://0.0.0.0:389"
+    ).is_listening
+
+    ldapsearch_query_stdout = container_per_test.connection.check_output(
+        'ldapsearch -x -D "cn=admin,dc=example,dc=com" -w admin -b "dc=example,dc=com" "(cn=mailAccountReader)" dn'
+    )
+    for resp in [
+        "dn: cn=mailAccountReader,ou=Manager,dc=example,dc=com",
+        "result: 0 Success",
+    ]:
+        assert resp in ldapsearch_query_stdout
+
+    container_per_test.connection.check_output(
+        'ldapadd -x -D "cn=admin,dc=example,dc=com" -w "admin" -f /entrypoint/ldif/examples/example-user.ldif',
+    )
+
+    sendmail_cmd = 'echo "Subject: Test Email\n\nThis is a test email body." | sendmail -f user1@example.com user2@example.com'
+    container_per_test.connection.check_output(sendmail_cmd)
+
+    assert "Mail queue is empty" in container_per_test.connection.check_output(
+        "sleep 10; mailq"
+    )
+
+    log = container_per_test.connection.file(
+        "/var/log/postfix.log"
+    ).content_string
+    for output in [
+        "from=<user1@example.com>",
+        "to=<user2@mail.example.com>, orig_to=<user2@example.com>",
+        "relay=localhost[127.0.0.1]:1025",
+        "dsn=2.0.0",
+        "status=sent (250 Ok: queued as",
+        "=@mailhog.example)",
+    ]:
+        assert output in log

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py36,py39,py310,py311,py312}-unit, build, all, base, fips, init, dotnet, python, ruby, node, go, openjdk, openjdk_devel, rust, php, busybox, 389ds, metadata, minimal, multistage, repository, doc, lint, get_urls, pcp, distribution, postgres, git, helm, nginx, kernel_module, mariadb, tomcat, spack, gcc, prometheus, grafana, kiwi
+envlist = {py36,py39,py310,py311,py312}-unit, build, all, base, fips, init, dotnet, python, ruby, node, go, openjdk, openjdk_devel, rust, php, busybox, 389ds, metadata, minimal, multistage, repository, doc, lint, get_urls, pcp, distribution, postgres, git, helm, nginx, kernel_module, mariadb, tomcat, spack, gcc, prometheus, grafana, kiwi, postfix
 isolated_build = True
 skip_missing_interpreters = True
 skip_install = True


### PR DESCRIPTION
PR adds basic smoke test for postfix container image (re: https://github.com/SUSE/BCI-dockerfile-generator/pull/1046)

To test (with postfix container image built in linked PR 1046):

```
OS_VERSION=tumbleweed TARGET=custom BASEURL=registry.opensuse.org/home/defolos/bci/staging/tumbleweed/tumbleweed-1046/ tox -e postfix

OS_VERSION=15.6 TARGET=custom BASEURL=registry.opensuse.org/home/defolos/bci/staging/sle-15-sp6/6-1046/ tox -e postfix
```


#### Known issue with:

```
OS_VERSION=15.5 TARGET=custom BASEURL=registry.opensuse.org/home/defolos/bci/staging/sle-15-sp5/5-1046/ tox -e postfix

# fails with 

/bin/sh -c \'ps -eo pid,cmd | grep \'"\'"\'^ *1 \'"\'"\' | sed \'"\'"\'s/^ *1 //\'"\'"\'\'', _stdout=b'', _stderr=b'/bin/sh: ps: command not found\n')
```

(missing `ps` command in `suse/sle15:15.5`)