### PR TITLE
add kernel-64kb-devel to allowed package names

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -326,7 +326,7 @@ def test_no_orphaned_packages(container_per_test: ContainerData) -> None:
     container_per_test.connection.check_output(
         f"timeout 5m zypper -n dup --from {BCI_REPO_NAME} -l "
         "--no-allow-vendor-change --no-allow-name-change --no-allow-arch-change "
-        "--allow-downgrade "
+        "--allow-downgrade"
     )
 
     searchresult = ET.fromstring(

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -117,6 +117,8 @@ def test_sle_bci_forbidden_packages(container_per_test):
         "kernel-devel",
         "kernel-syms",
         "kernel-syms-azure",
+        # aarch64 only
+        "kernel-64kb-devel",
     ]
 
     FORBIDDEN_PACKAGE_NAMES = ["kernel", "yast", "kvm", "xen"]


### PR DESCRIPTION
This should fix: https://openqa.suse.de/tests/14480268#step/_root_BCI-tests_repository_/5