### PR TITLE
Only replace the BCI_REPO url in containers where the file exists & is writeable

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -202,6 +202,7 @@ if BCI_DEVEL_REPO is None:
 else:
     _BCI_REPLACE_REPO_CONTAINERFILE = f"RUN sed -i 's|baseurl.*|baseurl={BCI_DEVEL_REPO}|' /etc/zypp/repos.d/{BCI_REPO_NAME}.repo"
 
+assert BCI_DEVEL_REPO, "BCI_DEVEL_REPO must be set at this point"
 
 _IMAGE_TYPE_T = Literal["dockerfile", "kiwi"]
 


### PR DESCRIPTION
This is not a perfect solution as tomcat still works with the old url (it's build with `USER tomcat`), but it's better than before