### PR TITLE
Force gem on SLE to use `--platform ruby` to install ffi

### DIFF
--- a/tests/test_ruby.py
+++ b/tests/test_ruby.py
@@ -34,7 +34,9 @@ def test_lang_set(auto_container):
 @pytest.mark.parametrize(
     "gem",
     [
-        "ffi",
+        (  # bsc1225821
+            ("--platform ruby " if OS_VERSION != "tumbleweed" else "") + "ffi"
+        ),
         "sqlite3 -v 1.4.0",  # bsc#1203692
         "rspec-expectations",
         "diff-lcs",


### PR DESCRIPTION
See: https://bugzilla.suse.com/show_bug.cgi?id=1225821