### PR TITLE
Test for the public cloud modules being installable as well

### DIFF
--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -168,6 +168,8 @@ def test_package_installation(container_per_test, pkg):
     "pkg",
     [
         "libsnmp30",  # bsc#1209442
+        "aws-cli",  # disappeared after python311 switch due to unresolvables
+        "python3-azure-sdk",  # might also become unresolvable
     ],
 )
 @pytest.mark.parametrize("container_per_test", [BASE_CONTAINER], indirect=True)
@@ -176,5 +178,5 @@ def test_sle15_packages(container_per_test, pkg):
     remain installable and available.
     """
     container_per_test.connection.check_output(
-        f"{_RM_ZYPPSERVICE}; zypper -n in -r {BCI_REPO_NAME} {pkg}"
+        f"{_RM_ZYPPSERVICE}; zypper -n in --dry-run -r {BCI_REPO_NAME} {pkg}"
     )


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
build, all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
