### PR TITLE
pin tenacity to < 8.4.0 as a hotfix for https://github.com/jd/tenacity/issues/471

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
     pytest-rerunfailures
     typing_extensions
     requests
-    tenacity
+    tenacity < 8.4.0
     git+https://github.com/dcermak/pytest_container
     doc: Sphinx
 


### PR DESCRIPTION
See https://github.com/jd/tenacity/issues/471

[CI:TOXENVS] nginx,mariadb,tomcat