### PR TITLE
Run FIPS tests in non-FIPS hosts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - id: setmatrix
         run: |
-          set stringified_matrix (tox -l | sed -e '/unit/d' -e '/get_urls/d' -e '/doc/d' -e '/lint/d' -e '/fips/d' | jo -a)
+          set stringified_matrix (tox -l | sed -e '/unit/d' -e '/get_urls/d' -e '/doc/d' -e '/lint/d' -e '/fips/d'  | jo -a)
 
           set users_envs (echo $PR_BODY | awk -F' ' '/^\[CI:TOXENVS\]/ { print $2 }')
           if [ -n "$users_envs" ]
@@ -118,6 +118,9 @@ jobs:
           - 15.6
           - "tumbleweed"
         include:
+          - toxenv: fips
+            testing_target: ibs-released
+            os_version: 15.3
           - toxenv: repository
             testing_target: ibs-released
             os_version: 15.5


### PR DESCRIPTION
For FIPS images we need to run the FIPS tests, even when those are running on non-FIPS hosts. Currently the FIPS tests are skipped on non-FIPS hosts. We need to add an exception for the FIPS images in BCI-Tests

[CI:TOXENVS] fips
