### PR TITLE
Reduce tumbleweed sizes

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -75,10 +75,10 @@ def test_base_size(auto_container: ContainerData, container_runtime):
         }
     elif OS_VERSION in ("basalt", "tumbleweed"):
         base_container_max_size: Dict[str, int] = {
-            "x86_64": 120,
-            "aarch64": 140,
-            "ppc64le": 172,
-            "s390x": 115,
+            "x86_64": 106,
+            "aarch64": 130,
+            "ppc64le": 142,
+            "s390x": 113,
         }
     # 15.5/15.6 are hopefully only temporary large due to PED-5014
     elif OS_VERSION in ("15.6",):

--- a/tests/test_minimal.py
+++ b/tests/test_minimal.py
@@ -19,10 +19,10 @@ SLE_MINIMAL_IMAGE_MAX_SIZE: Dict[str, int] = {
 }
 
 TW_MINIMAL_IMAGE_MAX_SIZE: Dict[str, int] = {
-    "x86_64": 51,
-    "aarch64": 51,
-    "s390x": 49,
-    "ppc64le": 59,
+    "aarch64": 65,
+    "ppc64le": 58,
+    "s390x": 41,
+    "x86_64": 49,
 }
 
 #: size limits of the micro image per architecture in MiB
@@ -35,8 +35,8 @@ SLE_MICRO_IMAGE_MAX_SIZE: Dict[str, int] = {
 
 TW_MICRO_IMAGE_MAX_SIZE: Dict[str, int] = {
     "x86_64": 34,
-    "aarch64": 36,
-    "s390x": 34,
+    "aarch64": 42,
+    "s390x": 28,
     "ppc64le": 41,
 }
 


### PR DESCRIPTION
We have stripped a bit further.

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
build, all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
