### PR TITLE
Remove container_from_pytest_param deprecated use

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -7,9 +7,8 @@ from typing import List
 from typing import Optional
 from typing import Sequence
 
-from pytest_container import container_and_marks_from_pytest_param
+from pytest_container.container import container_and_marks_from_pytest_param
 from pytest_container import DerivedContainer
-from pytest_container.container import container_from_pytest_param
 from pytest_container.container import ContainerVolume
 from pytest_container.container import PortForwarding
 from pytest_container.runtime import LOCALHOST
@@ -841,7 +840,7 @@ if __name__ == "__main__":
     print(
         json.dumps(
             [
-                container_from_pytest_param(cont).get_base().url
+                container_and_marks_from_pytest_param(cont)[0].get_base().url
                 for cont in ALL_CONTAINERS
                 if (not has_true_skipif(cont) and not has_xfail(cont))
             ]

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -7,7 +7,7 @@ from typing import Dict
 
 import pytest
 from pytest_container import DerivedContainer
-from pytest_container.container import container_from_pytest_param
+from pytest_container.container import container_and_marks_from_pytest_param
 from pytest_container.container import ContainerData
 from pytest_container.runtime import LOCALHOST
 
@@ -186,7 +186,7 @@ def test_all_openssl_hashes_known(auto_container):
 #: that docker can be launched inside the container
 DIND_CONTAINER = pytest.param(
     DerivedContainer(
-        base=container_from_pytest_param(BASE_CONTAINER),
+        base=container_and_marks_from_pytest_param(BASE_CONTAINER)[0],
         **{
             x: getattr(BASE_CONTAINER.values[0], x)
             for x in BASE_CONTAINER.values[0].__dict__

--- a/tests/test_kernel_module.py
+++ b/tests/test_kernel_module.py
@@ -1,7 +1,7 @@
 """Tests for the SLE15 kernel-module container."""
 
 import pytest
-from pytest_container import container_from_pytest_param
+from pytest_container import container_and_marks_from_pytest_param
 from pytest_container import DerivedContainer
 from pytest_container.container import ContainerData
 from pytest_container.runtime import LOCALHOST
@@ -22,7 +22,9 @@ _DRBD_VERSION = "9.2.7"
 def create_kernel_test(containerfile: str) -> pytest.param:
     return pytest.param(
         DerivedContainer(
-            base=container_from_pytest_param(KERNEL_MODULE_CONTAINER),
+            base=container_and_marks_from_pytest_param(
+                KERNEL_MODULE_CONTAINER
+            )[0],
             containerfile=containerfile,
         ),
         marks=KERNEL_MODULE_CONTAINER.marks,

--- a/tests/test_openjdk.py
+++ b/tests/test_openjdk.py
@@ -9,7 +9,7 @@ from dataclasses import field
 import pytest
 from pytest_container import DerivedContainer
 from pytest_container import Version
-from pytest_container.container import container_from_pytest_param
+from pytest_container.container import container_and_marks_from_pytest_param
 from pytest_container.container import ContainerData
 from pytest_container.runtime import LOCALHOST
 
@@ -38,7 +38,7 @@ CONTAINER_IMAGES = [
 CONTAINER_IMAGES_EXTENDED = [
     pytest.param(
         DerivedContainer(
-            base=container_from_pytest_param(container),
+            base=container_and_marks_from_pytest_param(container)[0],
             containerfile=DOCKERF_EXTENDED,
         ),
         marks=container.marks,
@@ -50,7 +50,7 @@ CONTAINER_IMAGES_EXTENDED = [
 CONTAINER_IMAGES_CASSANDRA = [
     pytest.param(
         DerivedContainer(
-            base=container_from_pytest_param(container),
+            base=container_and_marks_from_pytest_param(container)[0],
             containerfile=DOCKERF_CASSANDRA,
         ),
         marks=container.marks,

--- a/tests/test_php.py
+++ b/tests/test_php.py
@@ -6,7 +6,7 @@ except ImportError:
     from typing_extensions import Literal
 
 import pytest
-from pytest_container import container_from_pytest_param
+from pytest_container import container_and_marks_from_pytest_param
 from pytest_container import DerivedContainer
 from pytest_container import OciRuntimeBase
 from pytest_container.container import ContainerData
@@ -34,7 +34,7 @@ _MEDIAWIKI_VERSION = "1.39.2"
 _MEDIAWIKI_MAJOR_VERSION = ".".join(_MEDIAWIKI_VERSION.split(".")[:2])
 
 MEDIAWIKI_APACHE_CONTAINER = DerivedContainer(
-    base=container_from_pytest_param(PHP_8_APACHE),
+    base=container_and_marks_from_pytest_param(PHP_8_APACHE)[0],
     forwarded_ports=[PortForwarding(container_port=80)],
     image_format=ImageFormat.DOCKER,
     containerfile=f"""ENV MEDIAWIKI_VERSION={_MEDIAWIKI_VERSION}
@@ -66,7 +66,7 @@ EXPOSE 80
 
 
 MEDIAWIKI_FPM_CONTAINER = DerivedContainer(
-    base=container_from_pytest_param(PHP_8_FPM),
+    base=container_and_marks_from_pytest_param(PHP_8_FPM)[0],
     containerfile=f"""ENV MEDIAWIKI_VERSION={_MEDIAWIKI_VERSION}
 ENV MEDIAWIKI_MAJOR_VERSION={_MEDIAWIKI_MAJOR_VERSION}"""
     + r"""

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -7,7 +7,7 @@ from typing import Optional
 import psycopg2
 import pytest
 from _pytest.mark import ParameterSet
-from pytest_container.container import container_from_pytest_param
+from pytest_container.container import container_and_marks_from_pytest_param
 from pytest_container.container import ContainerData
 from pytest_container.container import DerivedContainer
 
@@ -38,7 +38,7 @@ def _generate_test_matrix() -> List[ParameterSet]:
     params = []
 
     for pg_cont_param in POSTGRESQL_CONTAINERS:
-        pg_cont = container_from_pytest_param(pg_cont_param)
+        pg_cont = container_and_marks_from_pytest_param(pg_cont_param)[0]
         marks = pg_cont_param.marks
         ports = pg_cont.forwarded_ports
         params.append(

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -7,7 +7,7 @@ import pytest
 from pytest_container import DerivedContainer
 from pytest_container import OciRuntimeBase
 from pytest_container import PortForwarding
-from pytest_container.container import container_from_pytest_param
+from pytest_container.container import container_and_marks_from_pytest_param
 from pytest_container.container import ContainerData
 from pytest_container.runtime import get_selected_runtime
 from pytest_container.runtime import LOCALHOST
@@ -49,7 +49,7 @@ CONTAINER_IMAGES = PYTHON_CONTAINERS
 CONTAINER_IMAGES_T1 = [
     pytest.param(
         DerivedContainer(
-            base=container_from_pytest_param(CONTAINER_T),
+            base=container_and_marks_from_pytest_param(CONTAINER_T)[0],
             containerfile=DOCKERF_PY_T1,
             forwarded_ports=[PortForwarding(container_port=PORT1)],
         ),
@@ -64,7 +64,7 @@ CONTAINER_IMAGES_T1 = [
 CONTAINER_IMAGES_T2 = [
     pytest.param(
         DerivedContainer(
-            base=container_from_pytest_param(CONTAINER_T),
+            base=container_and_marks_from_pytest_param(CONTAINER_T)[0],
             containerfile=DOCKERF_PY_T2,
         ),
         marks=CONTAINER_T.marks,


### PR DESCRIPTION
This silences a slightly annoying warning in the test outpu

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
build, all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
