### PR TITLE
Unrestrict tenacity again

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,8 @@ deps =
     pytest-rerunfailures
     typing_extensions
     requests
-    tenacity < 8.4.0
+    # 8.4.0 is borked: https://github.com/jd/tenacity/issues/471
+    tenacity != 8.4.0
     git+https://github.com/dcermak/pytest_container
     doc: Sphinx
 


### PR DESCRIPTION
https://github.com/jd/tenacity/issues/471 is fixed so we can stop requiring tenacity < 8.4.0 now

[CI:TOXENVS] nginx,tomcat,mariadb
