### PR TITLE
Install libsolv-tools for the installcheck

### DIFF
--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -61,6 +61,7 @@ def test_installcheck(container_per_test):
     """Run installcheck against the SLE_BCI repo + locally installed packages."""
     # Let zypper fetch the repo data and generate solv files.
     container_per_test.connection.check_output("zypper ref")
+    container_per_test.connection.check_output("zypper -n in libsolv-tools")
     # Check that all packages in SLE_BCI can be installed, using already installed
     # packages (@System) if necessary. It tries to keep rpm installed
     # but rpm-ndb conflicts with that, so exclude rpm-ndb.


### PR DESCRIPTION
15.6 and newer has gotten the new libzypp stack which strips libsolv-tools as a default dependency. so we need to install it explicitly as it is no longer in the container by default.

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
build, all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
