### PR TITLE
Install procps for cassandra tests

### DIFF
--- a/tests/test_openjdk.py
+++ b/tests/test_openjdk.py
@@ -26,7 +26,7 @@ COPY {HOST_TEST_DIR} {CONTAINER_TEST_DIR}
 """
 
 DOCKERF_CASSANDRA = """
-RUN zypper -n in tar gzip awk git-core util-linux
+RUN zypper -n in tar gzip awk git-core util-linux procps
 """
 
 CONTAINER_IMAGES = [


### PR DESCRIPTION
One of the scripts calls free that is included in the procps package and no longer shipped by default

[CI:TOXENVS] openjdk