### PR TITLE
Roll over Python:3.6, Ruby:2.5 & 389ds to 15 SP6

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -466,7 +466,7 @@ NODEJS_CONTAINERS = [
 ]
 
 PYTHON36_CONTAINER = create_BCI(
-    build_tag="bci/python:3.6", available_versions=["15.5"]
+    build_tag="bci/python:3.6", available_versions=["15.6"]
 )
 PYTHON310_CONTAINER = create_BCI(
     build_tag="bci/python:3.10", available_versions=["tumbleweed"]
@@ -490,7 +490,7 @@ PYTHON_WITH_PIPX_CONTAINERS = [
 ]
 
 RUBY_25_CONTAINER = create_BCI(
-    build_tag="bci/ruby:2.5", available_versions=["15.5"]
+    build_tag="bci/ruby:2.5", available_versions=["15.6"]
 )
 
 RUBY_33_CONTAINER = create_BCI(
@@ -585,7 +585,7 @@ CONTAINER_389DS_CONTAINERS = [
         forwarded_ports=[PortForwarding(container_port=3389)],
     )
     for ver, os_ver in (
-        ("2.2", "15.5"),
+        ("2.2", "15.6"),
         ("3.0", "tumbleweed"),
     )
 ]


### PR DESCRIPTION
[CI:TOXENVS] python,ruby,389ds

CC @mgrossu 