### PR TITLE
Temporarily activate back 15-SP5 version so we can release the images

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -467,7 +467,7 @@ NODEJS_CONTAINERS = [
 ]
 
 PYTHON36_CONTAINER = create_BCI(
-    build_tag="bci/python:3.6", available_versions=["15.6"]
+    build_tag="bci/python:3.6", available_versions=["15.5", "15.6"]
 )
 PYTHON310_CONTAINER = create_BCI(
     build_tag="bci/python:3.10", available_versions=["tumbleweed"]
@@ -491,7 +491,7 @@ PYTHON_WITH_PIPX_CONTAINERS = [
 ]
 
 RUBY_25_CONTAINER = create_BCI(
-    build_tag="bci/ruby:2.5", available_versions=["15.6"]
+    build_tag="bci/ruby:2.5", available_versions=["15.5", "15.6"]
 )
 
 RUBY_33_CONTAINER = create_BCI(
@@ -587,6 +587,7 @@ CONTAINER_389DS_CONTAINERS = [
     )
     for ver, os_ver in (
         ("2.2", "15.6"),
+        ("2.2", "15.5"),
         ("3.0", "tumbleweed"),
     )
 ]


### PR DESCRIPTION
The 15-SP5 version of [ruby](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP5&build=24.9_ruby-2.5-image&groupid=444),[389ds]( https://openqa.suse.de/tests/overview?distri=sle&version=15-SP5&build=26.6_389-ds-container&groupid=445), [python3.6](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP5&build=27.4_python-3.6-image&groupid=444) is failing.
Temporarily activate back 15-SP5 version so we can release the images till Wednesday. 

[CI:TOXENVS] python,ruby,389ds
