### PR TITLE
Rely on awk and procps being installed in the openjdk containers

### DIFF
--- a/tests/test_openjdk.py
+++ b/tests/test_openjdk.py
@@ -27,7 +27,7 @@ COPY {HOST_TEST_DIR} {CONTAINER_TEST_DIR}
 """
 
 DOCKERF_CASSANDRA = """
-RUN zypper -n in tar gzip awk git-core util-linux procps
+RUN zypper -n in tar gzip git-core util-linux
 """
 
 CONTAINER_IMAGES = [


### PR DESCRIPTION
This improves the test coverage here to ensure the packages are not forgotten.

Depends-On: https://github.com/SUSE/BCI-dockerfile-generator/pull/1349

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
build, all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
