### PR TITLE
Remove unused variables that are found by ruff 0.5.0

### DIFF
--- a/tests/test_mariadb.py
+++ b/tests/test_mariadb.py
@@ -109,9 +109,6 @@ def test_mariadb_db_env_vars(
     variables.
 
     """
-    conn = None
-    cur = None
-
     dbdir = "/var/lib/mysql"
 
     dbdir_f = container_per_test.connection.file(dbdir)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
build, all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
