### PR TITLE
skip installation of bci_tests module

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = {py36,py39,py310,py311,py312}-unit, build, all, base, fips, init, dotnet, python, ruby, node, go, openjdk, openjdk_devel, rust, php, busybox, 389ds, metadata, minimal, multistage, repository, doc, lint, get_urls, pcp, distribution, postgres, git, helm, nginx, kernel_module, mariadb, tomcat, spack, gcc
 isolated_build = True
 skip_missing_interpreters = True
+skip_install = True
 
 [common]
 deps =


### PR DESCRIPTION
We don't need it installed, so this saves a few fractions of a second on every tox run.

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
build, all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
