### PR TITLE
Renaming rpm present test in minimal

### DIFF
--- a/tests/test_minimal.py
+++ b/tests/test_minimal.py
@@ -104,7 +104,7 @@ def test_rpm_absent_in_micro(container):
 @pytest.mark.parametrize(
     "container", [MINIMAL_CONTAINER], indirect=["container"]
 )
-def test_rpm_present_in_micro(container):
+def test_rpm_present_in_minimal(container):
     """Ensure that rpm is present in the minimal container."""
     assert container.connection.exists(
         "rpm"


### PR DESCRIPTION
Rename the test that checks if rpm is present in minimal to `test_rpm_present_in_minimal`.