### PR TITLE
Disable CGO for certificate fetching test

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -54,7 +54,7 @@ func main() {
 MULTISTAGE_DOCKERFILE = """FROM $builder as builder
 WORKDIR /src
 COPY main.go .
-RUN go build main.go
+RUN CGO_ENABLED=0 GOOS=linux go build main.go
 
 FROM $runner
 ENTRYPOINT []


### PR DESCRIPTION
This test compiles a go binary which performs a `http.Get`. So far, we implicitly assumed that glibc would export the same symbols across all service packs (the golang builder image can be based on a different service pack). This was recently invalidated with SP6, hence we disable CGO and thereby do not rely on glibc symbols anymore.

[CI:TOXENVS] all