### PR TITLE
Fix variable name typo in assert message

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -55,7 +55,7 @@ _DEFAULT_NONBASE_OS_VERSIONS = ("15.6", "tumbleweed")
 
 assert (
     sorted(ALLOWED_BASE_OS_VERSIONS) == list(ALLOWED_BASE_OS_VERSIONS)
-), f"list ALLOWED_OS_VERSIONS must be sorted, but got {ALLOWED_BASE_OS_VERSIONS}"
+), f"list ALLOWED_BASE_OS_VERSIONS must be sorted, but got {ALLOWED_BASE_OS_VERSIONS}"
 
 assert (
     sorted(ALLOWED_NONBASE_OS_VERSIONS) == list(ALLOWED_NONBASE_OS_VERSIONS)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
build, all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
