### PR TITLE
Restore base container marks for 15.5

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -306,7 +306,7 @@ def create_BCI(
             for ver in available_versions:
                 if ver not in ALLOWED_BASE_OS_VERSIONS:
                     raise ValueError(
-                        f"Invalid os version for base container: {ver}"
+                        f"Invalid os version {ver} for base container: {build_tag}"
                     )
         else:
             available_versions = list(_DEFAULT_BASE_OS_VERSIONS)

--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -53,6 +53,9 @@ _DEFAULT_NONBASE_SLE_VERSIONS = ("15.5", "15.6")
 # Test Language and Application containers by default for these versions
 _DEFAULT_NONBASE_OS_VERSIONS = ("15.6", "tumbleweed")
 
+# Test base containers by default for these versions
+_DEFAULT_BASE_OS_VERSIONS = ("15.5", "15.6", "tumbleweed")
+
 assert (
     sorted(ALLOWED_BASE_OS_VERSIONS) == list(ALLOWED_BASE_OS_VERSIONS)
 ), f"list ALLOWED_BASE_OS_VERSIONS must be sorted, but got {ALLOWED_BASE_OS_VERSIONS}"
@@ -298,6 +301,15 @@ def create_BCI(
                     )
         else:
             available_versions = list(_DEFAULT_NONBASE_OS_VERSIONS)
+    else:
+        if available_versions:
+            for ver in available_versions:
+                if ver not in ALLOWED_BASE_OS_VERSIONS:
+                    raise ValueError(
+                        f"Invalid os version for base container: {ver}"
+                    )
+        else:
+            available_versions = list(_DEFAULT_BASE_OS_VERSIONS)
 
     if available_versions:
         marks.append(create_container_version_mark(available_versions))


### PR DESCRIPTION
The automatic setting of default marks only was working for development and application containers. restore it for base containers, as right now 15.5 is not in dev/app but it is in base containers.

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
build, all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
