### PR TITLE
Add TW spack testing

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -744,7 +744,7 @@ SPACK_CONTAINERS = [
         build_tag=f"{BCI_CONTAINER_PREFIX}/spack:{tag}",
         available_versions=[f"{ver}"],
     )
-    for ver, tag in (("15.6", "0.21"),)
+    for ver, tag in (("15.6", "0.21"), ("tumbleweed", "0.22"))
 ]
 
 PROMETHEUS_CONTAINERS = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ markers = [
     'bci-sle15-kernel-module-devel_15.5',
     'bci-sle15-kernel-module-devel_15.6',
     'spack_0.21',
+    'spack_0.22',
 ]
 
 [tool.ruff]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
build, all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
