### PR TITLE
Apply default configured base available versions for base containers

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -382,19 +382,16 @@ else:
 MINIMAL_CONTAINER = create_BCI(
     build_tag=f"{BCI_CONTAINER_PREFIX}/bci-minimal:{OS_CONTAINER_TAG}",
     image_type="kiwi",
-    available_versions=ALLOWED_BASE_OS_VERSIONS,
     bci_type=ImageType.OS,
 )
 MICRO_CONTAINER = create_BCI(
     build_tag=f"{BCI_CONTAINER_PREFIX}/bci-micro:{OS_CONTAINER_TAG}",
     image_type="kiwi",
-    available_versions=ALLOWED_BASE_OS_VERSIONS,
     bci_type=ImageType.OS,
 )
 BUSYBOX_CONTAINER = create_BCI(
     build_tag=f"{BCI_CONTAINER_PREFIX}/bci-busybox:{OS_CONTAINER_TAG}",
     image_type="kiwi",
-    available_versions=["15.4", "15.5", "15.6", "tumbleweed"],
     custom_entry_point="/bin/sh",
     bci_type=ImageType.OS,
 )
@@ -567,7 +564,6 @@ RUST_CONTAINERS = [
 
 INIT_CONTAINER = create_BCI(
     build_tag=f"{BCI_CONTAINER_PREFIX}/bci-init:{OS_CONTAINER_TAG}",
-    available_versions=["15.4", "15.5", "15.6", "tumbleweed"],
     bci_type=ImageType.OS,
     healthcheck_timeout=timedelta(seconds=240),
     extra_marks=[


### PR DESCRIPTION
With 3360ec54739628dc773291ebd130bddd28a05e80 we can now remove the available_version overrides as they're now centrally defined

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
build, all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
