### PR TITLE
bump the base-fips size a bit more

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -97,11 +97,12 @@ def test_base_size(auto_container: ContainerData, container_runtime):
             "s390x": 126,
         }
     elif OS_VERSION in ("15.4",):
+        # pick the sizes from sles15-ltss-image which is larger than sles15-ltsss
         base_container_max_size: Dict[str, int] = {
-            "x86_64": 118,
-            "aarch64": 135,
-            "ppc64le": 156,
-            "s390x": 122,
+            "x86_64": 121,
+            "aarch64": 142,
+            "ppc64le": 162,
+            "s390x": 125,
         }
     else:
         base_container_max_size: Dict[str, int] = {

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -72,7 +72,7 @@ def test_base_size(auto_container: ContainerData, container_runtime):
         # SP4+ is a lot larger as it pulls in python3 and
         # the FIPS crypto policy scripts
         base_container_max_size: Dict[str, int] = {
-            "x86_64": 130 if OS_VERSION in ("15.3",) else 168,
+            "x86_64": 130 if OS_VERSION in ("15.3",) else 169,
         }
     elif OS_VERSION in ("basalt", "tumbleweed"):
         base_container_max_size: Dict[str, int] = {


### PR DESCRIPTION
the actual container submitted to QA seems to be rounding up to a MB more. just bump it

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
build, all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
