### PR TITLE
Fix the url to download the GNU hello test project

### DIFF
--- a/tests/test_gcc.py
+++ b/tests/test_gcc.py
@@ -13,7 +13,7 @@ _HELLO_VERSION = "2.12.1"
 
 CONTAINERFILE_HELLO = f"""
 WORKDIR /src
-RUN curl -sLO https://ftpmirror.gnu.org/hello/hello-{_HELLO_VERSION}.tar.gz && \\
+RUN curl -sLO https://ftp.gnu.org/gnu/hello/hello-{_HELLO_VERSION}.tar.gz && \\
     tar --no-same-permissions --no-same-owner -xf hello-{_HELLO_VERSION}.tar.gz && \\
     cd hello-{_HELLO_VERSION} && \\
     ./configure && \\


### PR DESCRIPTION
[CI:TOXENVS] gcc