### PR TITLE
Stop testing on SP5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,7 +115,6 @@ jobs:
       matrix:
         toxenv: ${{fromJson(needs.gentestmatrix.outputs.matrix)}}
         os_version:
-          - 15.5
           - 15.6
           - "tumbleweed"
         include:
@@ -156,6 +155,24 @@ jobs:
             os_version: 15.4
           - toxenv: metadata
             os_version: 15.4
+          - toxenv: all
+            os_version: 15.5
+          - toxenv: base
+            os_version: 15.5
+          - toxenv: build
+            os_version: 15.5
+          - toxenv: busybox
+            os_version: 15.5
+          - toxenv: metadata
+            os_version: 15.5
+          - toxenv: minimal
+            os_version: 15.5
+          - toxenv: multistage
+            os_version: 15.5
+          - toxenv: repository
+            os_version: 15.5
+          - toxenv: init
+            os_version: 15.5
 
     steps:
       - name: Clean up disk space to maximize available space


### PR DESCRIPTION
We have switched over all non-base containers to SP6. Testing the SP5 containers no longer makes sense.

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
build, all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
