### PR TITLE
Check kernel containers for absence of systemd again

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -28,7 +28,6 @@ from bci_tester.data import CONTAINERS_WITH_ZYPPER
 from bci_tester.data import CONTAINERS_WITH_ZYPPER_AS_ROOT
 from bci_tester.data import DISTRIBUTION_CONTAINER
 from bci_tester.data import INIT_CONTAINER
-from bci_tester.data import KERNEL_MODULE_CONTAINER
 from bci_tester.data import OS_PRETTY_NAME
 from bci_tester.data import OS_VERSION
 from bci_tester.data import OS_VERSION_ID
@@ -388,16 +387,7 @@ def test_zypper_verify_passes(container: ContainerData) -> None:
     [
         c
         for c in ALL_CONTAINERS
-        if (
-            c
-            not in [
-                INIT_CONTAINER,
-                # kernel-module-container contains systemd due to pesign,
-                # fixes are pending
-                KERNEL_MODULE_CONTAINER,
-            ]
-            + PCP_CONTAINERS
-        )
+        if (c not in PCP_CONTAINERS + [INIT_CONTAINER])
     ],
     indirect=True,
 )


### PR DESCRIPTION
jsc#PED-7256 has been addressed, reenable testing

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
build, all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
