### PR TITLE
Correct lifetime url for Tumbleweed

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -434,7 +434,12 @@ GOLANG_CONTAINERS = (
     + [
         create_BCI(
             build_tag=f"{BCI_CONTAINER_PREFIX}/golang:{golang_version}",
-            extra_marks=[pytest.mark.__getattr__(f"golang_{golang_version}")],
+            extra_marks=[
+                pytest.mark.__getattr__(f"golang_{golang_version}"),
+                pytest.mark.skip(
+                    reason="There is no unstable golang at the moment"
+                ),
+            ],
             available_versions=["tumbleweed"],
         )
         for golang_version in ("unstable",)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -363,7 +363,7 @@ def test_general_labels(
 
     if OS_VERSION == "tumbleweed":
         assert labels["org.opensuse.lifecycle-url"] in (
-            "https://en.opensuse.org/Lifetime",
+            "https://en.opensuse.org/Lifetime#openSUSE_BCI",
         )
         # no EULA for openSUSE images
     else:


### PR DESCRIPTION
[CI:TOXENVS] metadata