### PR TITLE
Fix handling of the ironbank base container

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -379,15 +379,16 @@ else:
         image_type="kiwi",
         bci_type=ImageType.OS,
     )
-    BASE_FIPS_CONTAINERS = [
-        create_BCI(
-            build_tag=f"{BCI_CONTAINER_PREFIX}/bci-base-fips:{OS_CONTAINER_TAG}",
-            bci_type=ImageType.OS,
-            # TODO set to _DEFAULT_BASE_OS_VERSIONS once the fips containers are available
-            # everywhere
-            available_versions=("15.6",),
-        )
-    ]
+    if TARGET not in ("dso",):
+        BASE_FIPS_CONTAINERS = [
+            create_BCI(
+                build_tag=f"{BCI_CONTAINER_PREFIX}/bci-base-fips:{OS_CONTAINER_TAG}",
+                bci_type=ImageType.OS,
+                # TODO set to _DEFAULT_BASE_OS_VERSIONS once the fips containers are available
+                # everywhere
+                available_versions=("15.6",),
+            )
+        ]
     if TARGET in ("ibs", "ibs-cr", "ibs-released"):
         LTSS_BASE_CONTAINERS.extend(
             create_BCI(

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -16,6 +16,7 @@ from bci_tester.data import BASE_FIPS_CONTAINERS
 from bci_tester.data import LTSS_BASE_CONTAINERS
 from bci_tester.data import LTSS_BASE_FIPS_CONTAINERS
 from bci_tester.data import OS_VERSION
+from bci_tester.data import TARGET
 from bci_tester.fips import ALL_DIGESTS
 from bci_tester.fips import FIPS_DIGESTS
 from bci_tester.fips import host_fips_enabled
@@ -72,6 +73,7 @@ def test_base_size(container: ContainerData, container_runtime):
         and container.container.baseurl.rpartition("/")[2].startswith(
             "bci-base-fips"
         )
+        or TARGET in ("dso",)
     )
 
     #: size limits of the base container per arch in MiB
@@ -81,6 +83,9 @@ def test_base_size(container: ContainerData, container_runtime):
         base_container_max_size: Dict[str, int] = {
             "x86_64": 130 if OS_VERSION in ("15.3",) else 169,
         }
+        if TARGET in ("dso",):
+            # the dso container is larger than the bci-base-fips container
+            base_container_max_size["x86_64"] += 10
     elif OS_VERSION in ("tumbleweed",):
         base_container_max_size: Dict[str, int] = {
             "x86_64": 100,
@@ -183,7 +188,8 @@ def test_openssl_hashes(container):
 
 @pytest.mark.parametrize(
     "container_per_test",
-    [*LTSS_BASE_FIPS_CONTAINERS, *BASE_FIPS_CONTAINERS],
+    [*LTSS_BASE_FIPS_CONTAINERS, *BASE_FIPS_CONTAINERS]
+    + ([BASE_CONTAINER] if TARGET in ("dso",) else []),
     indirect=True,
 )
 def test_openssl_fips_hashes(container_per_test):


### PR DESCRIPTION
The ironbank base container is a fips container but actually called bci-base.

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
build, all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
