### PR TITLE
FIPS tests added for gnutls library

### DIFF
--- a/bci_tester/fips.py
+++ b/bci_tester/fips.py
@@ -64,6 +64,22 @@ ALL_DIGESTS: Tuple[str] = NONFIPS_DIGESTS + FIPS_DIGESTS
 
 assert len(set(ALL_DIGESTS)) == len(ALL_DIGESTS)
 
+#: gnutls digests that are not FIPS compliant
+NONFIPS_GNUTLS_DIGESTS: Tuple[str] = ("md5", "gostr341194", "streebog-256", "streebog-512")
+
+#: FIPS compliant gnutls digests
+FIPS_GNUTLS_DIGESTS: Tuple[str] = (
+    "sha1",
+    "sha224",
+    "sha256",
+    "sha384",
+    "sha512",
+)
+
+#: all digests supported by gnutls
+ALL_GNUTLS_DIGESTS: Tuple[str] = NONFIPS_GNUTLS_DIGESTS + FIPS_GNUTLS_DIGESTS
+
+assert len(set(ALL_GNUTLS_DIGESTS)) == len(ALL_GNUTLS_DIGESTS)
 
 def host_fips_supported(
     fipsfile: str = "/proc/sys/crypto/fips_enabled",

--- a/bci_tester/fips.py
+++ b/bci_tester/fips.py
@@ -65,7 +65,12 @@ ALL_DIGESTS: Tuple[str] = NONFIPS_DIGESTS + FIPS_DIGESTS
 assert len(set(ALL_DIGESTS)) == len(ALL_DIGESTS)
 
 #: gnutls digests that are not FIPS compliant
-NONFIPS_GNUTLS_DIGESTS: Tuple[str] = ("md5", "gostr341194", "streebog-256", "streebog-512")
+NONFIPS_GNUTLS_DIGESTS: Tuple[str] = (
+    "md5",
+    "gostr341194",
+    "streebog-256",
+    "streebog-512",
+)
 
 #: FIPS compliant gnutls digests
 FIPS_GNUTLS_DIGESTS: Tuple[str] = (
@@ -80,6 +85,7 @@ FIPS_GNUTLS_DIGESTS: Tuple[str] = (
 ALL_GNUTLS_DIGESTS: Tuple[str] = NONFIPS_GNUTLS_DIGESTS + FIPS_GNUTLS_DIGESTS
 
 assert len(set(ALL_GNUTLS_DIGESTS)) == len(ALL_GNUTLS_DIGESTS)
+
 
 def host_fips_supported(
     fipsfile: str = "/proc/sys/crypto/fips_enabled",

--- a/tests/files/fips-test-gnutls.c
+++ b/tests/files/fips-test-gnutls.c
@@ -18,34 +18,32 @@ int main(int argc, char *argv[]) {
     const char *mess2 = "Hello World\n";
     unsigned char md_value[128];
     size_t md_len;
+    int ret_code=1;
 
     if (argc < 2) {
         fprintf(stderr, "Usage: mdtest digestname\n");
-        return 1;
+        return ret_code;
     }
 
     gnutls_global_init();
     digest_algorithm = gnutls_digest_get_id(argv[1]);
     if (digest_algorithm == GNUTLS_DIG_UNKNOWN) {
         fprintf(stderr, "Unknown message digest %s\n", argv[1]);
-        gnutls_global_deinit();
-        return 1;
+        goto cleanup;
     }
 
     unsigned char hash1[64];
     size_t hash1_size = gnutls_hash_get_len(digest_algorithm);
     if (gnutls_hash_fast(digest_algorithm, (const unsigned char *)mess1, strlen(mess1), hash1) != GNUTLS_E_SUCCESS) {
         fprintf(stderr, "Hash calculation failed\n");
-        gnutls_global_deinit();
-        return 1;
+        goto cleanup;
     }
 
     unsigned char hash2[64];
     size_t hash2_size = gnutls_hash_get_len(digest_algorithm);
     if (gnutls_hash_fast(digest_algorithm, (const unsigned char *)mess2, strlen(mess2), hash2) != GNUTLS_E_SUCCESS) {
         fprintf(stderr, "Hash calculation failed\n");
-        gnutls_global_deinit();
-        return 1;
+        goto cleanup;
     }
 
     memcpy(md_value, hash1, hash1_size);
@@ -58,6 +56,10 @@ int main(int argc, char *argv[]) {
         printf("%02x", md_value[i]);
     }
     printf("\n");
+    ret_code=0;
+    goto cleanup;
 
-    return 0;
+    cleanup:
+        gnutls_global_deinit();
+        return ret_code;
 }

--- a/tests/files/fips-test-gnutls.c
+++ b/tests/files/fips-test-gnutls.c
@@ -1,0 +1,63 @@
+/** Simple C program that will calculate the hash of a fixed string using
+ * GnuTLS.
+ *
+ * The hash to be used is passed as the first parameter to the binary.
+ * This program demonstrates the use of GnuTLS for computing message digests.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <gnutls/gnutls.h>
+#include <gnutls/crypto.h>
+#include <stdlib.h>
+#include <assert.h>
+
+int main(int argc, char *argv[]) {
+    gnutls_digest_algorithm_t digest_algorithm;
+    const char *mess1 = "Test Message\n";
+    const char *mess2 = "Hello World\n";
+    unsigned char md_value[128];
+    size_t md_len;
+
+    if (argc < 2) {
+        fprintf(stderr, "Usage: mdtest digestname\n");
+        return 1;
+    }
+
+    gnutls_global_init();
+    digest_algorithm = gnutls_digest_get_id(argv[1]);
+    if (digest_algorithm == GNUTLS_DIG_UNKNOWN) {
+        fprintf(stderr, "Unknown message digest %s\n", argv[1]);
+        gnutls_global_deinit();
+        return 1;
+    }
+
+    unsigned char hash1[64];
+    size_t hash1_size = gnutls_hash_get_len(digest_algorithm);
+    if (gnutls_hash_fast(digest_algorithm, (const unsigned char *)mess1, strlen(mess1), hash1) != GNUTLS_E_SUCCESS) {
+        fprintf(stderr, "Hash calculation failed\n");
+        gnutls_global_deinit();
+        return 1;
+    }
+
+    unsigned char hash2[64];
+    size_t hash2_size = gnutls_hash_get_len(digest_algorithm);
+    if (gnutls_hash_fast(digest_algorithm, (const unsigned char *)mess2, strlen(mess2), hash2) != GNUTLS_E_SUCCESS) {
+        fprintf(stderr, "Hash calculation failed\n");
+        gnutls_global_deinit();
+        return 1;
+    }
+
+    memcpy(md_value, hash1, hash1_size);
+    memcpy(md_value + hash1_size, hash2, hash2_size);
+    md_len = hash1_size + hash2_size;
+
+    gnutls_global_deinit();
+    printf("Digest is: ");
+    for (size_t i = 0; i < md_len; i++) {
+        printf("%02x", md_value[i]);
+    }
+    printf("\n");
+
+    return 0;
+}

--- a/tests/test_fips.py
+++ b/tests/test_fips.py
@@ -190,4 +190,4 @@ def test_gnutls_binary(container_per_test: ContainerData) -> None:
             [1], f"/bin/fips-test-gnutls {digest}"
         ).stderr
 
-        assert f"Hash calculation failed" in err_msg
+        assert f"Hash calculation failed" in err_msg, f"Hash calculation unexpectedly succeeded for {digest}"

--- a/tests/test_fips.py
+++ b/tests/test_fips.py
@@ -12,8 +12,8 @@ from bci_tester.data import CONTAINERS_WITH_ZYPPER
 from bci_tester.data import LTSS_BASE_FIPS_CONTAINERS
 from bci_tester.data import OS_VERSION
 from bci_tester.fips import FIPS_DIGESTS
-from bci_tester.fips import NONFIPS_DIGESTS
 from bci_tester.fips import FIPS_GNUTLS_DIGESTS
+from bci_tester.fips import NONFIPS_DIGESTS
 from bci_tester.fips import NONFIPS_GNUTLS_DIGESTS
 from bci_tester.fips import NULL_DIGESTS
 from bci_tester.fips import host_fips_enabled
@@ -165,10 +165,10 @@ def fips_mode_setup_check(container_per_test: ContainerData) -> None:
 def test_openssl_fips_hashes(container_per_test: ContainerData):
     openssl_fips_hashes_test_fnct(container_per_test)
 
+
 @pytest.mark.parametrize(
     "container_per_test", FIPS_GNUTLS_TESTER_IMAGES, indirect=True
 )
-
 def test_gnutls_binary(container_per_test: ContainerData) -> None:
     """Check that a binary linked against Gnutls obeys the host's FIPS mode
     setting:
@@ -182,12 +182,30 @@ def test_gnutls_binary(container_per_test: ContainerData) -> None:
 
     """
 
-    for digest in FIPS_GNUTLS_DIGESTS:
-        container_per_test.connection.check_output(f"/bin/fips-test-gnutls {digest}")
+    expected_fips_gnutls_digests = [
+        "c87d25a09584c040f3bfc53b570199591deb10ba648a6a6ffffdaa0badb23b8baf90b6168dd16b3a",
+        "54655eae3d97147de34564572231c34d6d0917dd7852b5b93647fb4fe53ee97e5e0a2a4d359b5b461409dc44d9315afbc3b7d6bc5cd598e6",
+        "4ea6a95a3a56fa6b7c1673c145198c52265fea4fe4cebef97249b39c25a733a0d2a84f4b8b650937ec8f73cd8be2c74add5a911ba64df27458ed8229da804a26",
+        "416b69644f4844065fcfe7b60f14fe07d1573420c4db2b15a6d1f4cb2b6933ffce8dcb1bce7788b962eb3d0c8d4eefc4acbfd470c22c0d95a1d10a087dc31988b9f7bfeb13be70b876a73558be664e5858d11f9459923e6e5fd838cb5708b969",
+        "3916af571551c0c40eb19936c7ac2c090e140cad48e348dc4e9d5b6508a34ac6090daeeed3a081ce0e44c90b181987b71f09e8e0c190e5af26cd46eea724489de1c112ff908febc3b98b1693a6cd3564eaf8e5e6ca629d084d9f0eba99247cacdd72e369ff8941397c2807409ff66be64be908da17ad7b8a49a2a26c0e8086aa",
+    ]
+
+    for digest, expected_digest in zip(
+        FIPS_GNUTLS_DIGESTS, expected_fips_gnutls_digests
+    ):
+        container_per_test.connection.check_output(
+            f"/bin/fips-test-gnutls {digest}"
+        )
+        res = container_per_test.connection.run_expect(
+            [0], f"/bin/fips-test-gnutls {digest}"
+        )
+        assert expected_digest in res.stdout
 
     for digest in NONFIPS_GNUTLS_DIGESTS:
         err_msg = container_per_test.connection.run_expect(
             [1], f"/bin/fips-test-gnutls {digest}"
         ).stderr
 
-        assert f"Hash calculation failed" in err_msg, f"Hash calculation unexpectedly succeeded for {digest}"
+        assert (
+            "Hash calculation failed" in err_msg
+        ), f"Hash calculation unexpectedly succeeded for {digest}"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
build, all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
fixes #495 