### PR TITLE
Revert "Limit bci-repo tests to bci-base container"

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -22,6 +22,7 @@ from pytest_container.container import ContainerData
 
 from bci_tester.data import ALLOWED_BCI_REPO_OS_VERSIONS
 from bci_tester.data import ALL_CONTAINERS
+from bci_tester.data import BCI_DEVEL_REPO
 from bci_tester.data import BCI_REPO_NAME
 from bci_tester.data import BUSYBOX_CONTAINER
 from bci_tester.data import CONTAINERS_WITH_ZYPPER
@@ -34,6 +35,7 @@ from bci_tester.data import OS_VERSION
 from bci_tester.data import OS_VERSION_ID
 from bci_tester.data import PCP_CONTAINERS
 from bci_tester.data import POSTFIX_CONTAINERS
+from bci_tester.util import get_repos_from_connection
 
 CONTAINER_IMAGES = ALL_CONTAINERS
 
@@ -469,3 +471,107 @@ def test_certificates_are_present(
         [0],
         f"{container_runtime.runner_binary} run --rm {' '.join(get_extra_run_args(pytestconfig))} {img_id}",
     )
+
+
+@pytest.mark.skipif(
+    OS_VERSION not in ALLOWED_BCI_REPO_OS_VERSIONS,
+    reason="no included BCI repository - can't test",
+)
+@pytest.mark.parametrize(
+    "container_per_test", CONTAINERS_WITH_ZYPPER_AS_ROOT, indirect=True
+)
+def test_container_build_and_repo(container_per_test, host):
+    """Test all containers with zypper in them whether at least the ``SLE_BCI``
+    repository is present (if the host is unregistered). If a custom value for
+    the repository url has been supplied, then check that it is correct.
+
+    If the host is registered, then we check that there are more than one
+    repository present.
+
+    Additionally, check if the ``SLE_BCI_debug`` and ``SLE_BCI_source`` repos
+    are either both present or both absent. If both are present, enable them to
+    check that the URIs are valid.
+
+    """
+    # container-suseconnect will inject the correct repositories on registered
+    # SLES hosts
+    # => if the host is registered, we will have multiple repositories in the
+    # container, otherwise we will just have the SLE_BCI repository
+    suseconnect_injects_repos: bool = (
+        host.system_info.type == "linux"
+        and host.system_info.distribution == "sles"
+        and host.file("/etc/zypp/credentials.d/SCCcredentials").exists
+    )
+
+    repos = get_repos_from_connection(container_per_test.connection)
+    repo_names = {repo.name for repo in repos}
+
+    expected_repos = (
+        {
+            "openSUSE-Tumbleweed-Debug",
+            "openSUSE-Tumbleweed-Non-Oss",
+            "openSUSE-Tumbleweed-Oss",
+            "openSUSE-Tumbleweed-Source",
+            "openSUSE-Tumbleweed-Update",
+            "Open H.264 Codec (openSUSE Tumbleweed)",
+        }
+        if OS_VERSION == "tumbleweed"
+        else {
+            "SLE_BCI",
+            "SLE_BCI_debug",
+            "SLE_BCI_source",
+            "packages-microsoft-com-prod",
+        }
+    )
+
+    if suseconnect_injects_repos:
+        for _ in range(5):
+            if len(repos) > 1:
+                break
+
+            repos = get_repos_from_connection(container_per_test.connection)
+
+        assert (
+            len(repos) > 1
+        ), "On a registered host, we must have more than one repository on the host"
+    else:
+        assert len(repos) <= len(expected_repos)
+        assert not repo_names - expected_repos
+
+        if OS_VERSION == "tumbleweed":
+            for repo_name in "repo-debug", "repo-source":
+                container_per_test.connection.run_expect(
+                    [0], f"zypper modifyrepo --enable {repo_name}"
+                )
+
+    if OS_VERSION != "tumbleweed":
+        sle_bci_repo_candidates = [
+            repo for repo in repos if repo.name == "SLE_BCI"
+        ]
+        assert len(sle_bci_repo_candidates) == 1
+        sle_bci_repo = sle_bci_repo_candidates[0]
+
+        assert sle_bci_repo.name == "SLE_BCI"
+        assert sle_bci_repo.url == BCI_DEVEL_REPO
+
+        # find the debug and source repositories in the repo list, enable them so
+        # that we will check their url in the zypper ref call at the end
+        for repo_name in "SLE_BCI_debug", "SLE_BCI_source":
+            candidates = [repo for repo in repos if repo.name == repo_name]
+            assert len(candidates) in (0, 1)
+
+            if candidates:
+                container_per_test.connection.run_expect(
+                    [0], f"zypper modifyrepo --enable {candidates[0].alias}"
+                )
+
+        assert (
+            ("SLE_BCI_debug" in repo_names and "SLE_BCI_source" in repo_names)
+            or (
+                "SLE_BCI_debug" not in repo_names
+                and "SLE_BCI_source" not in repo_names
+            )
+        ), "repos SLE_BCI_source and SLE_BCI_debug must either both be present or both missing"
+
+    # check that all enabled repos are valid and can be refreshed
+    container_per_test.connection.run_expect([0], "zypper -n ref")


### PR DESCRIPTION
Reverts SUSE/BCI-tests#571

Reminder to re-enable testing on all containers