### PR TITLE
Reject packages with a SUSE-Firmware license in the BCI repo

### DIFF
--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -158,6 +158,26 @@ def test_package_installation(container_per_test, pkg):
 
 
 @pytest.mark.skipif(
+    OS_VERSION == "tumbleweed", reason="No testing for openSUSE"
+)
+@pytest.mark.skipif(
+    OS_VERSION not in ALLOWED_BCI_REPO_OS_VERSIONS,
+    reason="no included BCI repository - can't test",
+)
+@pytest.mark.parametrize("container_per_test", [BASE_CONTAINER], indirect=True)
+def test_repo_content_licensing(container_per_test) -> None:
+    conn = container_per_test.connection
+    conn.check_output("timeout 2m zypper ref && zypper -n in libsolv-tools")
+
+    assert (
+        conn.check_output(
+            f"set -o pipefail; dumpsolv /var/cache/zypp/solv/{BCI_REPO_NAME}/solv | sed -n '/^solvable:license:.*SUSE-Firmware/p' | wc -l"
+        ).strip()
+        == "0"
+    ), "Found a package with a SUSE-Firmware license"
+
+
+@pytest.mark.skipif(
     OS_VERSION not in ALLOWED_BCI_REPO_OS_VERSIONS,
     reason="no included BCI repository - can't test",
 )


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
