### PR TITLE
Unsorted list of lint fixes to get us above the threshold again

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -181,6 +181,7 @@ def test_openssl_hashes(container):
     indirect=True,
 )
 def test_openssl_fips_hashes(container_per_test):
+    """Check that all FIPS allowed hashes perform correctly."""
     openssl_fips_hashes_test_fnct(container_per_test)
 
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -23,7 +23,7 @@ _PUB_KEY = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMkxHs1b6A1kZuiu6nPxehkSO4pG4qMv
 
 _SSH_PORT = 22022
 
-_git_server_containerfile = rf"""
+_GIT_SERVER_CONTAINERFILE = rf"""
 RUN zypper -n in git-core openssh-server openssh-clients
 RUN ssh-keygen -A
 RUN useradd -U -m -p "*" git
@@ -86,7 +86,7 @@ def test_git_clone_https(auto_container_per_test):
 
 GIT_SERVER_CONTAINER = DerivedContainer(
     base="registry.suse.com/bci/bci-base:latest",
-    containerfile=_git_server_containerfile,
+    containerfile=_GIT_SERVER_CONTAINERFILE,
     image_format=ImageFormat.DOCKER,
     extra_launch_args=["--cap-add", "AUDIT_WRITE"],
 )

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -464,6 +464,7 @@ def test_disturl_can_be_checked_out(
             f"https://{disturl.hostname}/public/source/{src_project}/{src_package}",
             params={"rev": src_revision},
             cert=cert,
+            timeout=(5, 10),
         )
     except requests.exceptions.ConnectionError as e:
         if "suse.de" in disturl.hostname:

--- a/tests/test_ruby.py
+++ b/tests/test_ruby.py
@@ -30,18 +30,16 @@ def test_lang_set(auto_container):
     assert auto_container.connection.check_output("echo $LANG") == "C.UTF-8"
 
 
-_sqlite3 = "sqlite3"
-if OS_VERSION != "tumbleweed":
-    _sqlite3 += " -v 1.4.0"  # bsc#1203692
-
-
 @pytest.mark.parametrize(
     "gem",
     [
         (  # bsc1225821
             ("--platform ruby " if OS_VERSION != "tumbleweed" else "") + "ffi"
         ),
-        _sqlite3,
+        (
+            # bsc#1203692
+            "sqlite3" if OS_VERSION == "tumbleweed" else "sqlite3 -v 1.4.0"
+        ),
         "rspec-expectations",
         "diff-lcs",
         "rspec-mocks",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
