### PR TITLE
Skip "SLE BCI advertisement" test for SAC containers

### DIFF
--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -316,7 +316,10 @@ def test_general_labels(
         _get_container_label_prefix(container_name, container_type),
         "org.opencontainers.image",
     ):
-        if container_name != "base":
+        if (
+            container_name != "base"
+            and container_type != ImageType.SAC_APPLICATION
+        ):
             if OS_VERSION == "tumbleweed":
                 assert (
                     "based on the openSUSE Tumbleweed Base Container Image."


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
