### PR TITLE
Remove use of git in tests

### DIFF
--- a/tests/test_kiwi.py
+++ b/tests/test_kiwi.py
@@ -19,11 +19,7 @@ KIWI_CONTAINER_EXTENDED = []
 
 CONTAINERFILE_KIWI_EXTENDED = """
 RUN set -euo pipefail; \
-zypper -n in --no-recommends git-core; \
-zypper -n clean; \
-rm -rf /var/log/{lastlog,tallylog,zypper.log,zypp/history,YaST2}
-
-RUN git clone https://github.com/OSInside/kiwi
+    curl -Lsf -o - https://github.com/OSInside/kiwi/archive/refs/heads/master.tar.gz | tar xzf -
 """
 
 for kiwi_ctr in KIWI_CONTAINERS:

--- a/tests/test_postfix.py
+++ b/tests/test_postfix.py
@@ -29,12 +29,12 @@ HEALTHCHECK --interval=5s --timeout=10s --start-period=30s --retries=3 \
 
 CONTAINERFILE_POSTFIX_WITH_LDAP_ENABLED = """
 RUN set -euo pipefail; \
-zypper -n in --no-recommends git find openldap2 openldap2-client; \
+zypper -n in --no-recommends find openldap2 openldap2-client; \
 zypper -n clean; \
 rm -rf /var/log/{lastlog,tallylog,zypper.log,zypp/history,YaST2}
 
 # TODO: move postfix & openldap container files to bci-dockerfile-generator
-RUN git clone https://github.com/thkukuk/containers-mailserver.git && \
+RUN curl -Lsf -o - https://github.com/thkukuk/containers-mailserver/archive/refs/heads/master.tar.gz | tar xzf - \
     cd containers-mailserver/openldap && \
     cp -r ldif /entrypoint/ && \
     cp slapd.init.ldif /entrypoint/ && \


### PR DESCRIPTION
This is doing deep clones which takes forever. also the zypper installs prevent us from going with leaner base containers.

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
