### PR TITLE
Remove usage of zypper

### DIFF
--- a/tests/test_postfix.py
+++ b/tests/test_postfix.py
@@ -28,13 +28,9 @@ HEALTHCHECK --interval=5s --timeout=10s --start-period=30s --retries=3 \
 
 
 CONTAINERFILE_POSTFIX_WITH_LDAP_ENABLED = """
-RUN set -euo pipefail; \
-zypper -n in --no-recommends find openldap2 openldap2-client; \
-zypper -n clean; \
-rm -rf /var/log/{lastlog,tallylog,zypper.log,zypp/history,YaST2}
-
 # TODO: move postfix & openldap container files to bci-dockerfile-generator
-RUN curl -Lsf -o - https://github.com/thkukuk/containers-mailserver/archive/refs/heads/master.tar.gz | tar  --no-same-permissions --no-same-owner -xzf - && \
+RUN set -euo pipefail; \
+    curl -Lsf -o - https://github.com/thkukuk/containers-mailserver/archive/refs/heads/master.tar.gz | tar  --no-same-permissions --no-same-owner -xzf - && \
     cd containers-mailserver-master/openldap && \
     cp -r ldif /entrypoint/ && \
     cp slapd.init.ldif /entrypoint/ && \


### PR DESCRIPTION
There is no zypper anymore in bci micro based containers.

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
