### PR TITLE
Test for fips mode in gpgconf as well

### DIFF
--- a/tests/test_fips.py
+++ b/tests/test_fips.py
@@ -285,3 +285,14 @@ def test_gcrypt_binary(container_per_test: ContainerData) -> None:
             non_fips_call.rc == 1
             and "Failed to create hash context" in non_fips_call.stderr
         ), f"Hash calculation unexpectedly succeeded for {digest}"
+
+
+@pytest.mark.parametrize(
+    "container_per_test", FIPS_GCRYPT_TESTER_IMAGES, indirect=True
+)
+def test_gpgconf_binary(container_per_test: ContainerData) -> None:
+    """validate that gpgconf lists fips-mode"""
+
+    assert container_per_test.connection.check_output(
+        "gpgconf --show-versions | sed -n '/fips-mode:[yn]:/p' "
+    ).startswith("fips-mode:y:")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
