### PR TITLE
Add testing for kernel devel container on 16.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -165,6 +165,8 @@ jobs:
             os_version: "16.0"
           - toxenv: metadata
             os_version: "16.0"
+          - toxenv: kernel_module
+            os_version: "16.0"
 
     steps:
       - name: Clean up disk space to maximize available space


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
