### PR TITLE
Drop psycopg2 dependency

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,9 +21,8 @@ deps =
 [testenv]
 deps =
     {[common]deps}
-    # Require a recent version of psycopg2 to avoid poo#128900
-    # 2.9.6 was the most up-to-date when adding this dependency
-    psycopg2 >= 2.9.6
+    pg8000 < 1.27.0 ; python_version < "3.7"
+    pg8000 ; python_version >= "3.7"
     pymysql
 allowlist_externals =
     docker


### PR DESCRIPTION
This is obsolete (replacement is psycopg) and is a non-wheel binary extension which means the host needs to have postgresql-server-devel and python-devel installed, which is painful for tesing on minified distributions. Use a pure-python implementation instead.

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
