### PR TITLE
Run unit-tests for py 313

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py36,py39,py310,py311,py312}-unit, all, base, fips, init, dotnet, python, ruby, node, go, openjdk, openjdk_devel, rust, php, busybox, 389ds, metadata, minimal, multistage, repository, doc, lint, get_urls, pcp, distribution, postgres, git, helm, nginx, kernel_module, mariadb, tomcat, spack, gcc, prometheus, grafana, kiwi, postfix
+envlist = {py36,py39,py310,py311,py312,py313}-unit, all, base, fips, init, dotnet, python, ruby, node, go, openjdk, openjdk_devel, rust, php, busybox, 389ds, metadata, minimal, multistage, repository, doc, lint, get_urls, pcp, distribution, postgres, git, helm, nginx, kernel_module, mariadb, tomcat, spack, gcc, prometheus, grafana, kiwi, postfix
 isolated_build = True
 skip_missing_interpreters = True
 skip_install = True
@@ -44,7 +44,7 @@ passenv =
 commands =
     pytest -vv tests/test_{envname}.py --junitxml={toxinidir}/junit_{envname}.xml --pytest-container-log-level=debug []
 
-[testenv:{py36,py39,py310,py311,py312}-unit]
+[testenv:{py36,py39,py310,py311,py312,py313}-unit]
 commands =
     pytest -n auto tests/test_unit.py --junitxml={toxinidir}/junit_unit.xml []
 deps =


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
