### PR TITLE
Ensure we never ship gcc-build

### DIFF
--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -77,10 +77,12 @@ def test_sle_bci_forbidden_packages(container_per_test):
     """Regression test that no packages containing the following strings are in the
     ``SLE_BCI`` repository:
 
+    - ``gcc-build``
     - ``kernel``
-    - ``yast``
     - ``kvm``
+    - ``livepatch``
     - ``xen``
+    - ``yast``
 
     The following packages contain the above strings, but are ok to be shipped:
 
@@ -121,7 +123,16 @@ def test_sle_bci_forbidden_packages(container_per_test):
         "kernel-64kb-devel",
     ]
 
-    FORBIDDEN_PACKAGE_NAMES = ["kernel", "yast", "kvm", "xen"]
+    FORBIDDEN_PACKAGE_NAMES = [
+        "gcc-build",
+        "libstdc++-build-devel",
+        "libgccjit-build-devel",
+        "livepatch",
+        "kernel",
+        "yast",
+        "kvm",
+        "xen",
+    ]
 
     forbidden_packages = list(
         filter(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
