### PR TITLE
Only test gcc 14 on sle15

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -767,9 +767,8 @@ GCC_CONTAINERS = [
         available_versions=os_versions,
     )
     for gcc_version, os_versions in (
-        (7, ("15.6",)),
         (13, ("15.6", "tumbleweed")),
-        (14, ("tumbleweed",)),
+        (14, ("15.6", "tumbleweed")),
     )
 ]
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
