### PR TITLE
Temporarily skip startup test on ppc64le

### DIFF
--- a/bci_tester/runtime_choice.py
+++ b/bci_tester/runtime_choice.py
@@ -1,3 +1,5 @@
+"""Provide helper variables to determine which runtime is used for this test run."""
+
 from pytest_container import get_selected_runtime
 
 #: Is :command:`docker` the selected runtime?

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -44,6 +44,12 @@ class TestSystemd:
     def test_systemd_boottime(self, auto_container):
         """Ensure the container startup time is below 5 seconds"""
 
+        # FIXME: Temporary workaround: While using emulated workers, the startup time test doesn't make sense.'
+        if auto_container.connection.system_info.arch == "ppc64le":
+            pytest.skip(
+                "boottime test temporarily disabled on emulated ppc64le workers."
+            )
+
         # Container startup time limit in seconds - aarch64 workers are slow sometimes.
         startup_limit = (
             11


### PR DESCRIPTION
Due to worker unavailability we need to run ppc64le on emulated workers at the moment where the startup times are always larger than the threshold. Therefore there is no point in running this test at all on ppc64le at the moment.

[CI:TOXENVS] init