### PR TITLE
Remove node 20 from SP7 and Tumbleweed

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -519,7 +519,7 @@ NODEJS_18_CONTAINER = create_BCI(
 )
 NODEJS_20_CONTAINER = create_BCI(
     build_tag="bci/nodejs:20",
-    available_versions=_DEFAULT_NONBASE_OS_VERSIONS,
+    available_versions=["15.6"],
 )
 
 NODEJS_22_CONTAINER = create_BCI(

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -52,6 +52,10 @@ def test_iconv_working(auto_container):
     )
 
 
+@pytest.mark.xfail(
+    OS_VERSION in ("tumbleweed",),
+    reason="https://bugzilla.opensuse.org/show_bug.cgi?id=1233235",
+)
 @pytest.mark.skipif(
     not PODMAN_SELECTED,
     reason="docker size reporting is dependant on underlying filesystem",


### PR DESCRIPTION
It has been replaced by 22 in both.

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
