### PR TITLE
Temporarily increase timeouts

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -44,7 +44,7 @@ class TestSystemd:
     def test_systemd_boottime(self, auto_container):
         """Ensure the container startup time is below 5 seconds"""
 
-        # FIXME: Temporary workaround: While using emulated workers, the startup time test doesn't make sense.'
+        # https://github.com/SUSE/BCI-tests/issues/647
         if auto_container.connection.system_info.arch == "ppc64le":
             pytest.skip(
                 "boottime test temporarily disabled on emulated ppc64le workers."

--- a/tests/test_mariadb.py
+++ b/tests/test_mariadb.py
@@ -13,6 +13,7 @@ from pytest_container.container import DerivedContainer
 from pytest_container.container import container_and_marks_from_pytest_param
 from pytest_container.pod import Pod
 from pytest_container.pod import PodData
+from pytest_container.runtime import LOCALHOST
 from pytest_container.runtime import OciRuntimeBase
 from tenacity import retry
 from tenacity import stop_after_attempt
@@ -82,10 +83,11 @@ def _generate_test_matrix() -> List[ParameterSet]:
     return params
 
 
-## FIXME Increased attempts from 5 to 8 due to https://github.com/SUSE/BCI-tests/issues/647
 @retry(
     wait=wait_exponential(multiplier=1, min=4, max=10),
-    stop=stop_after_attempt(8),
+    stop=stop_after_attempt(
+        8 if LOCALHOST.system_info.arch == "ppc64le" else 5
+    ),
 )
 def _wait_for_server(connection):
     connection.check_output("healthcheck.sh --connect")

--- a/tests/test_mariadb.py
+++ b/tests/test_mariadb.py
@@ -82,9 +82,10 @@ def _generate_test_matrix() -> List[ParameterSet]:
     return params
 
 
+## FIXME Increased attempts from 5 to 8 due to https://github.com/SUSE/BCI-tests/issues/647
 @retry(
     wait=wait_exponential(multiplier=1, min=4, max=10),
-    stop=stop_after_attempt(5),
+    stop=stop_after_attempt(8),
 )
 def _wait_for_server(connection):
     connection.check_output("healthcheck.sh --connect")

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -11,6 +11,7 @@ from _pytest.mark import ParameterSet
 from pytest_container.container import ContainerData
 from pytest_container.container import DerivedContainer
 from pytest_container.container import container_and_marks_from_pytest_param
+from pytest_container.runtime import LOCALHOST
 
 from bci_tester.data import POSTGRESQL_CONTAINERS
 from bci_tester.data import POSTGRES_PASSWORD
@@ -67,9 +68,12 @@ def _generate_test_matrix() -> List[ParameterSet]:
                         extra_launch_args=(
                             ["--user", username] if username else []
                         ),
-                        healthcheck_timeout=timedelta(
-                            seconds=180
-                        ),  # FIXME https://github.com/SUSE/BCI-tests/issues/647
+                        # FIXME https://github.com/SUSE/BCI-tests/issues/647
+                        healthcheck_timeout=(
+                            timedelta(minutes=3)
+                            if LOCALHOST.system_info.arch == "ppc64le"
+                            else None
+                        ),
                     ),
                     pg_user,
                     pw,

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -68,7 +68,7 @@ def _generate_test_matrix() -> List[ParameterSet]:
                         extra_launch_args=(
                             ["--user", username] if username else []
                         ),
-                        # FIXME https://github.com/SUSE/BCI-tests/issues/647
+                        # https://github.com/SUSE/BCI-tests/issues/647
                         healthcheck_timeout=(
                             timedelta(minutes=3)
                             if LOCALHOST.system_info.arch == "ppc64le"

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -1,5 +1,6 @@
 """Tests for the PostgreSQL related application container images."""
 
+from datetime import timedelta
 from itertools import product
 from typing import List
 from typing import Optional
@@ -66,6 +67,9 @@ def _generate_test_matrix() -> List[ParameterSet]:
                         extra_launch_args=(
                             ["--user", username] if username else []
                         ),
+                        healthcheck_timeout=timedelta(
+                            seconds=180
+                        ),  # FIXME https://github.com/SUSE/BCI-tests/issues/647
                     ),
                     pg_user,
                     pw,


### PR DESCRIPTION
Increase the timeouts for container startup temporarily due to the need of using emulated ppc workers.

[CI:TOXENVS] postgres,mariadb