### PR TITLE
Skip glob repo on ppc64

### DIFF
--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -42,6 +42,12 @@ def test_node_version(auto_container):
             GitRepositoryBuild(
                 repository_url="https://github.com/isaacs/node-glob",
                 build_command="npm ci && npm test",
+                marks=[
+                    pytest.mark.skipif(
+                        LOCALHOST.system_info.arch == "ppc64le",
+                        reason="glob tests timeout on emulated ppc64 workers",
+                    )
+                ],
             ),
             GitRepositoryBuild(
                 repository_url="https://github.com/tj/commander.js.git",


### PR DESCRIPTION
Skip the glob repository test on PPC64 because it runs into timeouts on the emulated ppc64 workers.

* Related failure: https://openqa.suse.de/tests/15932882#step/bci_test_podman/60

[CI:TOXENVS] node