### PR TITLE
Revert "xfail the codestream check"

### DIFF
--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -195,10 +195,6 @@ def test_repo_content_licensing(container_per_test) -> None:
     ),
     reason="no included BCI repository",
 )
-@pytest.mark.xfail(
-    OS_VERSION in ("15.7",),
-    reason="https://bugzilla.suse.com/show_bug.cgi?id=1232535",
-)
 @pytest.mark.parametrize("container_per_test", [BASE_CONTAINER], indirect=True)
 def test_codestream_lifecycle(container_per_test):
     """Check that the codestream lifecycle information is available


### PR DESCRIPTION
The underlying errneous code stream lifecycle change in SP7 was fixed.

This reverts commit 5079686142a467cc8d9f050e0d9ee8b7fd69f70d.
[CI:TOXENVS] repository

