### PR TITLE
Fix selinux check

### DIFF
--- a/bci_tester/selinux.py
+++ b/bci_tester/selinux.py
@@ -1,6 +1,5 @@
 """Module with helper utilities around SELinux."""
 
-import os
 from pathlib import Path
 
 try:
@@ -12,13 +11,18 @@ except ImportError:
 
 
 def selinux_status(
-    selinux_sysfs_dir: str = "/sys/fs/selinux/",
+    _selinux_sysfs_dir: str = "/sys/fs/selinux/",
 ) -> Literal["enforcing", "permissive", "disabled"]:
     """Returns the host's SELinux status"""
-    if not os.listdir(selinux_sysfs_dir):
+
+    selinux_sysfs_dir = Path(_selinux_sysfs_dir)
+
+    if not (
+        selinux_sysfs_dir.exists() and (selinux_sysfs_dir / "enforce").exists()
+    ):
         return "disabled"
 
-    if (Path(selinux_sysfs_dir) / "enforce").read_text().strip() == "1":
+    if (selinux_sysfs_dir / "enforce").read_text().strip() == "1":
         return "enforcing"
 
     return "permissive"


### PR DESCRIPTION
os.listdir() on a nonexisting directory raises an exception. we can just test for directory and file existance instead.

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
