### PR TITLE
Test python 3.13 on tumbleweed as well

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -553,7 +553,7 @@ PYTHON312_CONTAINER = create_BCI(
 )
 
 PYTHON313_CONTAINER = create_BCI(
-    build_tag="bci/python:3.13", available_versions=["15.7"]
+    build_tag="bci/python:3.13", available_versions=["15.7", "tumbleweed"]
 )
 
 PYTHON_CONTAINERS = [


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
