### PR TITLE
Adjust sizings for the SLFO base container

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -95,9 +95,9 @@ def test_base_size(container: ContainerData, container_runtime):
         }
     elif OS_VERSION in ("16.0",):
         base_container_max_size: Dict[str, int] = {
-            "x86_64": 158,
-            "aarch64": 178,
-            "ppc64le": 194,
+            "x86_64": 154,
+            "aarch64": 174,
+            "ppc64le": 189,
             "s390x": 155,
         }
     elif OS_VERSION in ("15.7",):


### PR DESCRIPTION
we switched to libcurl4-mini, adjust sizings.

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
