### PR TITLE
Enable postgresql 17 testing on SLE15 SP6

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -744,7 +744,7 @@ POSTGRESQL_CONTAINERS = [
         (14, ["tumbleweed"]),
         (15, ["15.5", "tumbleweed"]),
         (16, _DEFAULT_NONBASE_OS_VERSIONS),
-        (17, ["tumbleweed"]),
+        (17, ["15.6", "tumbleweed"]),
     )
 ]
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
