### PR TITLE
Added test for openJDK in FIPS mode

### DIFF
--- a/tests/files/JCEProviderInfo.java
+++ b/tests/files/JCEProviderInfo.java
@@ -1,0 +1,26 @@
+import java.security.Provider;
+import java.security.Provider.Service;
+import java.security.Security;
+
+public class JCEProviderInfo {
+    public static void main(final String[] args) {
+        System.err.printf("JCE Provider Info: %s %s/%s on %s %s%n", System.getProperty("java.vm.name"),
+                          System.getProperty("java.runtime.version"),
+                          System.getProperty("java.vm.version"),
+                          System.getProperty("os.name"),
+                          System.getProperty("os.version"));
+
+        System.err.printf("Listing all JCA Security Providers%n");
+        final Provider[] providers = Security.getProviders();
+        if (providers.length == 0) {
+            System.err.println("no providers available");
+            System.exit(1);
+        }
+        for (final Provider p : providers) {
+            System.out.printf("--- Provider %s %s%n    info %s%n", p.getName(), p.getVersionStr(), p.getInfo());
+            for(Service s : p.getServices()) {
+                System.out.printf(" + %s.%s : %s (%s)%n  tostring=%s%n", s.getType(), s.getAlgorithm(), s.getClassName(), s.getProvider().getName(), s.toString());
+            }
+        }
+    }
+}

--- a/tests/files/Tcheck.java
+++ b/tests/files/Tcheck.java
@@ -1,0 +1,17 @@
+import javax.net.ssl.SSLContext;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Security;
+
+public class Tcheck {
+
+	public static void main(String[] args) {
+		int i = 1;
+		System.out.println("Supported Security Providers:");
+		Provider [] providers = Security.getProviders();
+
+		for (Provider provider: providers) {
+			System.out.println(" " + i++ + ". " + provider.getInfo());
+		}
+	}
+}

--- a/tests/test_openjdk.py
+++ b/tests/test_openjdk.py
@@ -312,5 +312,5 @@ def test_openjdk_sec_providers(container_per_test: ContainerData) -> None:
     """
     c = container_per_test.connection
 
-    c.run_expect([0], "java JCEProviderInfo.java")
+    c.check_output("java JCEProviderInfo.java")
     assert "1. SunPKCS11-NSS-FIPS" in c.check_output("java Tcheck.java")


### PR DESCRIPTION
Add new test to verify if security providers are set propperly after enabling FIPS mode in openJDK containers.

https://progress.opensuse.org/issues/167683

[CI:TOXENVS] openjdk