### PR TITLE
Add testing for the python 3.9 SAC container

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -260,6 +260,7 @@ class ImageType(enum.Enum):
     """
 
     LANGUAGE_STACK = enum.auto()
+    SAC_LANGUAGE_STACK = enum.auto()
     APPLICATION = enum.auto()
     SAC_APPLICATION = enum.auto()
     OS = enum.auto()
@@ -268,12 +269,11 @@ class ImageType(enum.Enum):
     def __str__(self) -> str:
         if self.value == ImageType.OS_LTSS:
             return "suse/ltss"
-        return (
-            "application"
-            if self.value
-            in (ImageType.APPLICATION.value, ImageType.SAC_APPLICATION.value)
-            else "bci"
-        )
+        if self.value == ImageType.APPLICATION.value:
+            return "application"
+        if self.value == ImageType.SAC_APPLICATION.value:
+            return "application"
+        return "bci"
 
 
 def create_BCI(
@@ -568,37 +568,37 @@ NODEJS_CONTAINERS = [
     NODEJS_22_CONTAINER,
 ]
 
-PYTHON36_CONTAINER = create_BCI(
-    build_tag="bci/python:3.6", available_versions=["15.6"]
-)
-PYTHON310_CONTAINER = create_BCI(
-    build_tag="bci/python:3.10", available_versions=["tumbleweed"]
-)
-PYTHON311_CONTAINER = create_BCI(
-    build_tag="bci/python:3.11",
-    available_versions=_DEFAULT_NONBASE_OS_VERSIONS,
-)
-
-PYTHON312_CONTAINER = create_BCI(
-    build_tag="bci/python:3.12", available_versions=["15.6", "tumbleweed"]
-)
-
-PYTHON313_CONTAINER = create_BCI(
-    build_tag="bci/python:3.13", available_versions=["15.7", "tumbleweed"]
-)
-
-PYTHON_CONTAINERS = [
-    PYTHON36_CONTAINER,
-    PYTHON310_CONTAINER,
-    PYTHON311_CONTAINER,
-    PYTHON312_CONTAINER,
-    PYTHON313_CONTAINER,
+PYTHON_WITH_PIPX_CONTAINERS = [
+    create_BCI(
+        build_tag=f"{BCI_CONTAINER_PREFIX}/python:{ver}",
+        available_versions=versions,
+    )
+    for ver, versions in (
+        ("3.10", ["tumbleweed"]),
+        ("3.12", ["15.6", "tumbleweed"]),
+        ("3.13", ["15.7", "tumbleweed"]),
+    )
 ]
 
-PYTHON_WITH_PIPX_CONTAINERS = [
-    PYTHON310_CONTAINER,
-    PYTHON312_CONTAINER,
-    PYTHON313_CONTAINER,
+PYTHON_CONTAINERS = PYTHON_WITH_PIPX_CONTAINERS + [
+    create_BCI(
+        build_tag=f"{BCI_CONTAINER_PREFIX}/python:{ver}",
+        available_versions=versions,
+    )
+    for ver, versions in (
+        ("3.6", ["15.6"]),
+        ("3.11", _DEFAULT_NONBASE_OS_VERSIONS),
+    )
+]
+
+# Python containers on SUSE Application Collection
+SAC_PYTHON_CONTAINERS = [
+    create_BCI(
+        build_tag=f"{SAC_CONTAINER_PREFIX}/python:{ver}",
+        available_versions=versions,
+        bci_type=ImageType.SAC_LANGUAGE_STACK,
+    )
+    for ver, versions in (("3.9", ["15.6"]), ("3.11", ["15.6"]))
 ]
 
 RUBY_25_CONTAINER = create_BCI(
@@ -993,6 +993,7 @@ CONTAINERS_WITH_ZYPPER = (
     + PCP_CONTAINERS
     + PROMETHEUS_CONTAINERS
     + PYTHON_CONTAINERS
+    + SAC_PYTHON_CONTAINERS
     + RUBY_CONTAINERS
     + RUST_CONTAINERS
     + SPACK_CONTAINERS
@@ -1073,6 +1074,7 @@ else:
         + OPENJDK_CONTAINERS
         + PCP_CONTAINERS
         + PYTHON_CONTAINERS
+        + SAC_PYTHON_CONTAINERS
         + RUBY_CONTAINERS
         + RUST_CONTAINERS
         + SPACK_CONTAINERS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,7 @@ markers = [
     'postgres_17',
     'prometheus_2',
     'prometheus_3',
+    'python_3.9',
     'python_3.10',
     'python_3.11',
     'python_3.12',

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -367,6 +367,15 @@ def test_no_orphaned_packages(container_per_test: ContainerData) -> None:
         "prometheus-blackbox_exporter",
     }
 
+    python39_stack_packages = {
+        "libpython3_9-1_0",
+        "python39",
+        "python39-base",
+        "python39-devel",
+        "python39-pip",
+        "python39-setuptools",
+    }
+
     # kubic-locale-archive should be replaced by glibc-locale-base in the containers
     # but that is a few bytes larger so we accept it as an exception
     known_orphaned_packages = {
@@ -378,7 +387,7 @@ def test_no_orphaned_packages(container_per_test: ContainerData) -> None:
         "sle-module-basesystem-release",
         "sle-module-python3-release",
         "sle-module-server-applications-release",
-    }.union(monitoring_stack_packages)
+    }.union(monitoring_stack_packages).union(python39_stack_packages)
     assert not orphaned_packages.difference(known_orphaned_packages)
 
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -85,6 +85,7 @@ from bci_tester.data import PYTHON_CONTAINERS
 from bci_tester.data import RUBY_25_CONTAINER
 from bci_tester.data import RUBY_33_CONTAINER
 from bci_tester.data import RUST_CONTAINERS
+from bci_tester.data import SAC_PYTHON_CONTAINERS
 from bci_tester.data import SPACK_CONTAINERS
 from bci_tester.data import TOMCAT_CONTAINERS
 from bci_tester.data import ImageType
@@ -167,6 +168,10 @@ IMAGES_AND_NAMES: List[ParameterSet] = [
         (NGINX_CONTAINER, "nginx", ImageType.APPLICATION),
     ]
     + [(c, "python", ImageType.LANGUAGE_STACK) for c in PYTHON_CONTAINERS]
+    + [
+        (c, "python", ImageType.SAC_LANGUAGE_STACK)
+        for c in SAC_PYTHON_CONTAINERS
+    ]
     + [(c, "base-fips", ImageType.OS) for c in BASE_FIPS_CONTAINERS]
     + [
         (container_pcp, "pcp", ImageType.APPLICATION)
@@ -360,7 +365,10 @@ def test_general_labels(
                 "https://www.opensuse.org",
                 "https://www.opensuse.org/",
             )
-        elif container_type in (ImageType.SAC_APPLICATION,):
+        elif container_type in (
+            ImageType.SAC_LANGUAGE_STACK,
+            ImageType.SAC_APPLICATION,
+        ):
             expected_url = (
                 f"https://apps.rancher.io/applications/{container_name}",
             )
@@ -394,6 +402,7 @@ def test_general_labels(
         if container_type in (
             ImageType.OS_LTSS,
             ImageType.APPLICATION,
+            ImageType.SAC_LANGUAGE_STACK,
             ImageType.SAC_APPLICATION,
         ):
             assert labels["com.suse.eula"] == "sle-eula"
@@ -616,7 +625,10 @@ def test_reference(
         else:
             assert reference.startswith("registry.opensuse.org/opensuse/bci/")
     else:
-        if container_type == ImageType.SAC_APPLICATION:
+        if container_type in (
+            ImageType.SAC_LANGUAGE_STACK,
+            ImageType.SAC_APPLICATION,
+        ):
             assert reference.startswith("dp.apps.rancher.io/containers/")
         elif container_type == ImageType.APPLICATION or (
             OS_VERSION == "15.5" and container_name in ("base",)

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -16,6 +16,7 @@ from pytest_container.runtime import get_selected_runtime
 from bci_tester.data import OS_VERSION
 from bci_tester.data import PYTHON_CONTAINERS
 from bci_tester.data import PYTHON_WITH_PIPX_CONTAINERS
+from bci_tester.data import SAC_PYTHON_CONTAINERS
 from bci_tester.runtime_choice import PODMAN_SELECTED
 
 BCDIR = "/tmp/"
@@ -41,7 +42,7 @@ COPY {ORIG + APPDIR}/{APPL1}  {APPDIR}
 """
 
 #: Base containers under test, input of auto_container fixture
-CONTAINER_IMAGES = PYTHON_CONTAINERS
+CONTAINER_IMAGES = PYTHON_CONTAINERS + SAC_PYTHON_CONTAINERS
 
 
 #: Derived containers, from custom Dockerfile including additional test files
@@ -174,8 +175,8 @@ def test_pip_install_source_cryptography(auto_container_per_test):
         "echo $PYTHON_VERSION"
     )
 
-    if packaging.version.Version(version) < packaging.version.Version("3.8"):
-        pytest.skip("cryptography tests only supported on >= 3.8")
+    if packaging.version.Version(version) < packaging.version.Version("3.10"):
+        pytest.skip("cryptography tests only supported on >= 3.10")
 
     # install dependencies
     auto_container_per_test.connection.run_expect(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
