### PR TITLE
Add xfail for the openjdk-devel on ppc64le issue

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -485,19 +485,25 @@ OPENJDK_11_CONTAINER = create_BCI(
     build_tag="bci/openjdk:11", available_versions=["15.5", "tumbleweed"]
 )
 OPENJDK_DEVEL_11_CONTAINER = create_BCI(
-    build_tag="bci/openjdk-devel:11", available_versions=["15.5", "tumbleweed"]
+    build_tag="bci/openjdk-devel:11",
+    available_versions=["15.5", "tumbleweed"],
+    custom_entry_point="/bin/sh",
 )
 OPENJDK_17_CONTAINER = create_BCI(
     build_tag="bci/openjdk:17", available_versions=["15.5", "tumbleweed"]
 )
 OPENJDK_DEVEL_17_CONTAINER = create_BCI(
-    build_tag="bci/openjdk-devel:17", available_versions=["15.5", "tumbleweed"]
+    build_tag="bci/openjdk-devel:17",
+    available_versions=["15.5", "tumbleweed"],
+    custom_entry_point="/bin/sh",
 )
 OPENJDK_21_CONTAINER = create_BCI(
     build_tag="bci/openjdk:21", available_versions=["15.6", "tumbleweed"]
 )
 OPENJDK_DEVEL_21_CONTAINER = create_BCI(
-    build_tag="bci/openjdk-devel:21", available_versions=["15.6", "tumbleweed"]
+    build_tag="bci/openjdk-devel:21",
+    available_versions=["15.6", "tumbleweed"],
+    custom_entry_point="/bin/sh",
 )
 OPENJDK_23_CONTAINER = create_BCI(
     build_tag="bci/openjdk:23", available_versions=["tumbleweed"]

--- a/tests/test_openjdk_devel.py
+++ b/tests/test_openjdk_devel.py
@@ -7,6 +7,7 @@ import pytest
 from pytest_container import DerivedContainer
 from pytest_container import container_and_marks_from_pytest_param
 from pytest_container.container import ContainerData
+from pytest_container.runtime import LOCALHOST
 
 from bci_tester.data import OPENJDK_DEVEL_11_CONTAINER
 from bci_tester.data import OPENJDK_DEVEL_17_CONTAINER
@@ -86,6 +87,10 @@ def test_maven_present(auto_container):
     assert auto_container.connection.run_expect([0], "mvn --version")
 
 
+@pytest.mark.xfail(
+    LOCALHOST.system_info.arch == "ppc64le",
+    reason="https://bugzilla.suse.com/show_bug.cgi?id=1221983",
+)
 @pytest.mark.parametrize(
     "container,java_version",
     CONTAINER_IMAGES_WITH_VERSION,
@@ -112,10 +117,7 @@ def test_entrypoint(container, java_version, host, container_runtime):
 )
 @pytest.mark.parametrize("java_file", ["Basic"])
 def test_compile(container, java_file: str):
-    """Verify that the entry point of the OpenJDK devel container is the
-    :command:`jshell`.
-
-    """
+    """Verify that we can compile a simple java application successfully."""
     container.connection.check_output(
         f"ls {CONTAINER_TEST_DIR}{java_file}.java"
     )


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
