### PR TITLE
Adjust sizing of base container for 16.0

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -66,7 +66,6 @@ def test_base_size(container: ContainerData, container_runtime):
     :py:const:`base_container_max_size`
 
     """
-
     # the FIPS container is bigger too than the 15 SP3 base image
     is_fips_ctr = (
         container.container.baseurl
@@ -95,10 +94,10 @@ def test_base_size(container: ContainerData, container_runtime):
         }
     elif OS_VERSION in ("16.0",):
         base_container_max_size: Dict[str, int] = {
-            "x86_64": 154,
-            "aarch64": 174,
-            "ppc64le": 189,
-            "s390x": 155,
+            "x86_64": 100,
+            "aarch64": 126,
+            "ppc64le": 138,
+            "s390x": 99,
         }
     elif OS_VERSION in ("15.7",):
         base_container_max_size: Dict[str, int] = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
