### PR TITLE
Added test for openJDK in FIPS mode. Fixes issue #614

### DIFF
--- a/tests/files/JCEProviderInfo.java
+++ b/tests/files/JCEProviderInfo.java
@@ -1,0 +1,26 @@
+import java.security.Provider;
+import java.security.Provider.Service;
+import java.security.Security;
+
+public class JCEProviderInfo {
+    public static void main(final String[] args) {
+        System.err.printf("JCE Provider Info: %s %s/%s on %s %s%n", System.getProperty("java.vm.name"),
+                          System.getProperty("java.runtime.version"),
+                          System.getProperty("java.vm.version"),
+                          System.getProperty("os.name"),
+                          System.getProperty("os.version"));
+
+        System.err.printf("Listing all JCA Security Providers%n");
+        final Provider[] providers = Security.getProviders();
+        if (providers.length == 0) {
+            System.err.println("no providers available");
+            System.exit(1);
+        }
+        for (final Provider p : providers) {
+            System.out.printf("--- Provider %s %s%n    info %s%n", p.getName(), p.getVersionStr(), p.getInfo());
+            for(Service s : p.getServices()) {
+                System.out.printf(" + %s.%s : %s (%s)%n  tostring=%s%n", s.getType(), s.getAlgorithm(), s.getClassName(), s.getProvider().getName(), s.toString());
+            }
+        }
+    }
+}

--- a/tests/files/Tcheck.java
+++ b/tests/files/Tcheck.java
@@ -1,0 +1,17 @@
+import javax.net.ssl.SSLContext;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Security;
+
+public class Tcheck {
+
+	public static void main(String[] args) {
+		int i = 1;
+		System.out.println("Supported Security Providers:");
+		Provider [] providers = Security.getProviders();
+
+		for (Provider provider: providers) {
+			System.out.println(" " + i++ + ". " + provider.getInfo());
+		}
+	}
+}

--- a/tests/test_openjdk.py
+++ b/tests/test_openjdk.py
@@ -30,6 +30,23 @@ DOCKERF_CASSANDRA = """
 RUN zypper -n in tar gzip git-core util-linux
 """
 
+DOCKERFILE_OPENJDK_FIPS = """WORKDIR /src/
+COPY tests/files/Tcheck.java tests/files/JCEProviderInfo.java /src/
+ENV NSS_FIPS 1
+RUN zypper -n in mozilla-nss* java-$JAVA_VERSION-openjdk-devel
+"""
+
+FIPS_OPENJDK_IMAGES = []
+
+for param in [OPENJDK_17_CONTAINER, OPENJDK_21_CONTAINER]:
+    ctr, marks = container_and_marks_from_pytest_param(param)
+    tester_ctr = DerivedContainer(
+        containerfile=DOCKERFILE_OPENJDK_FIPS, base=ctr
+    )
+    FIPS_OPENJDK_IMAGES.append(
+        pytest.param(tester_ctr, marks=marks, id=param.id)
+    )
+
 CONTAINER_IMAGES = [
     OPENJDK_11_CONTAINER,
     OPENJDK_17_CONTAINER,
@@ -280,3 +297,19 @@ def test_jdk_cassandra(container_per_test):
     container_per_test.connection.check_output(
         f"cd /tmp/{cassandra_base}/tools/bin/ && ./cassandra-stress write n=1 && ./cassandra-stress read n=1",
     )
+
+
+@pytest.mark.parametrize(
+    "container_per_test",
+    FIPS_OPENJDK_IMAGES,
+    indirect=True,
+)
+def test_openjdk_sec_providers(container_per_test: ContainerData) -> None:
+    """
+    Verifies that the primary security provider in FIPS-enabled OpenJDK
+    containers is `SunPKCS11-NSS-FIPS`. The test uses Java scripts to list and
+    validate security providers, ensuring FIPS compliance.
+    """
+    c = container_per_test.connection
+    c.check_output("java JCEProviderInfo.java")
+    assert "1. SunPKCS11-NSS-FIPS" in c.check_output("java Tcheck.java")


### PR DESCRIPTION
Add new test to verify if security providers are set propperly after enabling FIPS mode in openJDK containers.

https://progress.opensuse.org/issues/167683

[CI:TOXENVS] openjdk