### PR TITLE
Add bci-base-fips testing for 15.7, 16.0 and tumbleweed

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -399,6 +399,13 @@ if OS_VERSION == "tumbleweed":
         image_type="kiwi",
         bci_type=ImageType.OS,
     )
+    BASE_FIPS_CONTAINERS.append(
+        create_BCI(
+            build_tag=f"{BCI_CONTAINER_PREFIX}/bci-base-fips:{OS_CONTAINER_TAG}",
+            bci_type=ImageType.OS,
+            available_versions=["tumbleweed"],
+        )
+    )
 else:
     BASE_CONTAINER = create_BCI(
         build_tag=f"{BCI_CONTAINER_PREFIX}/bci-base:{OS_CONTAINER_TAG}",
@@ -406,15 +413,17 @@ else:
         bci_type=ImageType.OS,
     )
     if TARGET not in ("dso",):
-        BASE_FIPS_CONTAINERS = [
+        BASE_FIPS_CONTAINERS.append(
             create_BCI(
                 build_tag=f"{BCI_CONTAINER_PREFIX}/bci-base-fips:{OS_CONTAINER_TAG}",
                 bci_type=ImageType.OS,
-                # TODO set to _DEFAULT_BASE_OS_VERSIONS once the fips containers are available
-                # everywhere
-                available_versions=("15.6",),
+                available_versions=[
+                    ver
+                    for ver in _DEFAULT_BASE_OS_VERSIONS
+                    if ver not in ("15.5",)
+                ],
             )
-        ]
+        )
     if TARGET in ("ibs", "ibs-cr", "ibs-released"):
         LTSS_BASE_CONTAINERS.extend(
             create_BCI(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ markers = [
     'bci-base-fips_15.5',
     'bci-base-fips_15.6',
     'bci-base-fips_15.7',
+    'bci-base-fips_16.0',
+    'bci-base-fips_latest',
     'bci-busybox_15.3',
     'bci-busybox_15.4',
     'bci-busybox_15.5',


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
