### PR TITLE
Adjust for newer /more stable helm container tagging

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -795,7 +795,7 @@ GIT_CONTAINER = create_BCI(
     image_type="kiwi",
 )
 
-_HELM_APP_VERSION = "latest" if OS_VERSION == "tumbleweed" else "3.13"
+_HELM_APP_VERSION = "latest" if OS_VERSION == "tumbleweed" else "3"
 
 HELM_CONTAINER = create_BCI(
     build_tag=f"{APP_CONTAINER_PREFIX}/helm:{_HELM_APP_VERSION}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ markers = [
     'git_2.35',
     'git_2.43',
     'git_latest',
-    'helm_3.13',
+    'helm_3',
     'helm_latest',
     'nginx_1.21',
     'nginx_latest',


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
