### PR TITLE
Update to more stable tag for kiwi on tumbleweed

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -395,7 +395,7 @@ KIWI_CONTAINERS = [
         ("15.6", "9.24"),
         ("15.7", "9.24"),
         ("16.0", "10.1"),
-        ("tumbleweed", "10.1"),
+        ("tumbleweed", "latest"),
     )
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ markers = [
     'grafana_11',
     'kiwi_9.24',
     'kiwi_10.1',
+    'kiwi_latest',
     'mariadb_10.11',
     'mariadb_11.6',
     'mariadb-client_10.11',


### PR DESCRIPTION
It recently updated from 10.1 to 10.2, we can just list `:latest` which is available and pointing to the right container.

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
