### PR TITLE
Avoid removesuffix()

### DIFF
--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -385,7 +385,7 @@ def test_general_labels(
         # no EULA for openSUSE images
     else:
         assert (
-            labels["com.suse.lifecycle-url"].removesuffix("/")
+            labels["com.suse.lifecycle-url"]
             in (
                 "https://www.suse.com/lifecycle#suse-linux-enterprise-server-15",
                 "https://www.suse.com/lifecycle",  # SLE 15 SP5 base container has incorrect URL


### PR DESCRIPTION
This function was only introduced in python 3.9, but QA tests with python 3.6.

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
