### PR TITLE
Limit softfailure for bsc#1221983 to JDK21

### DIFF
--- a/tests/test_openjdk_devel.py
+++ b/tests/test_openjdk_devel.py
@@ -87,13 +87,23 @@ def test_maven_present(auto_container):
     assert auto_container.connection.run_expect([0], "mvn --version")
 
 
-@pytest.mark.xfail(
-    LOCALHOST.system_info.arch == "ppc64le",
-    reason="https://bugzilla.suse.com/show_bug.cgi?id=1221983",
-)
 @pytest.mark.parametrize(
     "container,java_version",
-    CONTAINER_IMAGES_WITH_VERSION,
+    # Softfailure for bsc#1221983 only applies to OpenJDK-devel-21
+    [
+        param
+        if param.values[1] != 21
+        else pytest.param(
+            *param.values,
+            id=param.id,
+            marks=param.marks
+            + pytest.mark.xfail(
+                condition=LOCALHOST.system_info.arch == "ppc64le",
+                reason="https://bugzilla.suse.com/show_bug.cgi?id=1221983",
+            ),
+        )
+        for param in CONTAINER_IMAGES_WITH_VERSION
+    ],
     indirect=["container"],
 )
 def test_entrypoint(container, java_version, host, container_runtime):


### PR DESCRIPTION
The jshell failure is only present on OpenJDK-devel 21, so we need to limit the softfailure also to just this Java version. See https://bugzilla.suse.com/show_bug.cgi?id=1221983#c1

[CI:TOXENVS] openjdk_devel

### Verification runs:

* [openjdk-devel-11](https://openqa.suse.de/tests/16183529#step/_root_BCI-tests_openjdk_/4)
* [openjdk-devel-17](https://openqa.suse.de/tests/16183530#step/_root_BCI-tests_openjdk_/4)
* [openjdk-devel-21](https://openqa.suse.de/tests/16183531#step/_root_BCI-tests_openjdk_/4)