### PR TITLE
Expand the list of pre-cached hostnames with the new ones

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -387,7 +387,7 @@ jobs:
       - name: Add /etc/host entries
         run: |
           # precache dns entries to avoid timeouts in the runs later
-          for host in index.crates.io proxy.golang.org updates.suse.com registry.suse.com registry.opensuse.org download.opensuse.org cdn.opensuse.org packages.microsoft.com; do
+          for host in index.crates.io proxy.golang.org installer-updates.suse.com public-dl.suse.com updates.suse.com registry.suse.com registry.opensuse.org download.opensuse.org cdn.opensuse.org packages.microsoft.com; do
             echo -e "$(getent ahostsv4 $host | grep STREAM | cut -d' ' -f1 | head -n 1)\t$host"  | sudo tee -a /etc/hosts
           done
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
