### PR TITLE
Fix repository substitution for Tumbleweed

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -628,15 +628,17 @@ def test_container_build_and_repo(container_per_test, host):
                     [0], f"zypper modifyrepo --enable {repo_name}"
                 )
 
-    if OS_VERSION != "tumbleweed":
-        sle_bci_repo_candidates = [
-            repo for repo in repos if repo.name == "SLE_BCI"
-        ]
-        assert len(sle_bci_repo_candidates) == 1
-        sle_bci_repo = sle_bci_repo_candidates[0]
+    sle_bci_repo_candidates = [
+        repo
+        for repo in repos
+        if repo.name in ("SLE_BCI", "openSUSE-Tumbleweed-Oss")
+    ]
+    assert len(sle_bci_repo_candidates) == 1
+    sle_bci_repo = sle_bci_repo_candidates[0]
+    assert sle_bci_repo.url == BCI_DEVEL_REPO
 
+    if OS_VERSION != "tumbleweed":
         assert sle_bci_repo.name == "SLE_BCI"
-        assert sle_bci_repo.url == BCI_DEVEL_REPO
 
         # find the debug and source repositories in the repo list, enable them so
         # that we will check their url in the zypper ref call at the end


### PR DESCRIPTION
There is no perl anymore, and we also didn't check that the substitution actually happened.

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
