### PR TITLE
[appcol] Skip application collection containers on non aarch64 & x86_64

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -322,6 +322,15 @@ def create_BCI(
         for m in extra_marks:
             marks.append(m)
 
+    if bci_type in (ImageType.SAC_APPLICATION, ImageType.SAC_LANGUAGE_STACK):
+        marks.append(
+            pytest.mark.skipif(
+                condition=LOCALHOST.system_info.arch
+                not in ("x86_64", "aarch64"),
+                reason="Application collection containers are only available for x86_64 and aarch64",
+            )
+        )
+
     # Ironbank currently has only the "bci-base" image and nothing else, so
     # skip all other tests
     if TARGET == "dso" and (


### PR DESCRIPTION
In https://github.com/SUSE/BCI-tests/pull/675 we added a new appcol python 3.11 container that uses the same test marker as the bci python 3.11 container. This makes it impossible to filter only one of these containers which now causes problems in QA on ppc64le and s390x because the application collection containers are not available on those architectures. This is a quick hotfix, that makes the QA jobs pass again, we must still fix the markers.