### PR TITLE
Add initial milvus container testing

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -983,6 +983,14 @@ OPENWEBUI_CONTAINER = create_BCI(
     forwarded_ports=[PortForwarding(container_port=8080)],
 )
 
+MILVUS_CONTAINER = create_BCI(
+    build_tag=f"{SAC_CONTAINER_PREFIX}/milvus:2.4",
+    bci_type=ImageType.SAC_APPLICATION,
+    available_versions=["15.6-ai"],
+    custom_entry_point="/bin/bash",
+)
+
+
 CONTAINERS_WITH_ZYPPER = (
     [
         BASE_CONTAINER,
@@ -1047,6 +1055,7 @@ CONTAINERS_WITHOUT_ZYPPER = [
     MICRO_CONTAINER,
     MINIMAL_CONTAINER,
     OLLAMA_CONTAINER,
+    MILVUS_CONTAINER,
     *POSTFIX_CONTAINERS,
     *TOMCAT_CONTAINERS,
     *POSTGRESQL_CONTAINERS,
@@ -1076,6 +1085,7 @@ else:
             PHP_8_FPM,
             OLLAMA_CONTAINER,
             OPENWEBUI_CONTAINER,
+            MILVUS_CONTAINER,
         ]
         + BASE_FIPS_CONTAINERS
         + CONTAINER_389DS_CONTAINERS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ markers = [
     'git_latest',
     'helm_3',
     'helm_latest',
+    'milvus_2.4',
     'nginx_1.21',
     'nginx_latest',
     'golang_oldstable',

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -6,13 +6,11 @@ from tenacity import retry
 from tenacity import stop_after_attempt
 from tenacity import wait_exponential
 
+from bci_tester.data import MILVUS_CONTAINER
 from bci_tester.data import OLLAMA_CONTAINER
 from bci_tester.data import OPENWEBUI_CONTAINER
 
-CONTAINER_IMAGES = (
-    OLLAMA_CONTAINER,
-    OPENWEBUI_CONTAINER,
-)
+CONTAINER_IMAGES = (OLLAMA_CONTAINER, OPENWEBUI_CONTAINER, MILVUS_CONTAINER)
 
 
 @pytest.mark.parametrize(
@@ -57,3 +55,19 @@ def test_openwebui_health(container_per_test):
         assert ":true" in resp.text
 
     check_openwebui_response()
+
+
+@pytest.mark.parametrize(
+    "container_per_test",
+    [MILVUS_CONTAINER],
+    indirect=["container_per_test"],
+)
+def test_milvus_health(container_per_test):
+    """Test the milvus container."""
+
+    # doesn't allow running outside kubernetes as far as I can see
+    container_per_test.connection.check_output(
+        "minio-client -q --dp --version"
+    )
+    container_per_test.connection.check_output("etcd --version")
+    container_per_test.connection.check_output("milvus")

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -56,6 +56,7 @@ from bci_tester.data import LTSS_BASE_FIPS_CONTAINERS
 from bci_tester.data import MARIADB_CLIENT_CONTAINERS
 from bci_tester.data import MARIADB_CONTAINERS
 from bci_tester.data import MICRO_CONTAINER
+from bci_tester.data import MILVUS_CONTAINER
 from bci_tester.data import MINIMAL_CONTAINER
 from bci_tester.data import NGINX_CONTAINER
 from bci_tester.data import NODEJS_18_CONTAINER
@@ -289,6 +290,7 @@ IMAGES_AND_NAMES: List[ParameterSet] = [
     + [
         (OLLAMA_CONTAINER, "ollama", ImageType.SAC_APPLICATION),
         (OPENWEBUI_CONTAINER, "open-webui", ImageType.SAC_APPLICATION),
+        (MILVUS_CONTAINER, "milvus", ImageType.SAC_APPLICATION),
     ]
 ]
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
