### PR TITLE
kea dhcp4 testing

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -856,6 +856,19 @@ KUBECTL_CONTAINERS = [
     for kubectl_ver, os_versions in _KUBECTL_VERSION_OS_MATRIX
 ]
 
+_KEA_VERSION_OS_MATRIX: Tuple[Tuple[str, Tuple[str, ...]], ...] = (
+    ("2.6", ("tumbleweed", "15.7")),
+)
+
+KEA_CONTAINERS = [
+    create_BCI(
+        build_tag=f"{APP_CONTAINER_PREFIX}/kea:{kea_ver}",
+        bci_type=ImageType.APPLICATION,
+        available_versions=os_versions,
+    )
+    for kea_ver, os_versions in _KEA_VERSION_OS_MATRIX
+]
+
 if OS_VERSION in ("16.0",):
     KERNEL_MODULE_CONTAINER = create_BCI(
         build_tag=f"{BCI_CONTAINER_PREFIX}/bci-sle16-kernel-module-devel:{OS_CONTAINER_TAG}",
@@ -1053,6 +1066,7 @@ CONTAINERS_WITH_ZYPPER = (
     + RUST_CONTAINERS
     + SPACK_CONTAINERS
     + (DOTNET_CONTAINERS if LOCALHOST.system_info.arch == "x86_64" else [])
+    + KEA_CONTAINERS
 )
 
 #: all containers with zypper and with the flag to launch them as root

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ markers = [
     'golang_unstable',
     'grafana_10',
     'grafana_11',
+    'kea_2.6',
     'kiwi_9.24',
     'kiwi_10.1',
     'kiwi_latest',

--- a/tests/files/kea-dhcp4.conf
+++ b/tests/files/kea-dhcp4.conf
@@ -1,0 +1,48 @@
+{
+    "Dhcp4": {
+        "interfaces-config": {
+            "interfaces": ["*"]
+        },
+        "subnet4": [
+        {
+            "subnet": "172.25.0.0/16",
+            "pools": [
+            { "pool": "172.25.1.100 - 172.25.1.200" }
+            ],
+            "option-data": [
+            { "name": "routers", "data": "172.25.0.1" }
+            ],
+            "id": 1
+        }
+        ],
+        "lease-database": {
+            "type": "memfile",
+            "persist": true,
+            "name": "/var/lib/kea/dhcp4.leases"
+        },
+        "loggers": [
+            {
+                "name": "kea-dhcp4",
+                "output_options": [
+                {
+                    "output": "/tmp/kea-dhcp4.log",
+                    "maxsize": 1048576,
+                    "maxver": 8
+                }
+                ],
+                "severity": "DEBUG"
+            },
+            {
+                "name": "kea-dhcp4.packets",
+                "output_options": [
+                {
+                    "output": "/tmp/kea-dhcp4-packets.log",
+                    "maxver": 10
+                }
+                ],
+                "severity": "DEBUG",
+                "debuglevel": 99
+            }
+       ]
+    }
+}

--- a/tests/test_kea.py
+++ b/tests/test_kea.py
@@ -1,0 +1,98 @@
+import json
+import os
+import re
+
+import pytest
+from pytest_container import DerivedContainer
+from pytest_container.container import ContainerLauncher
+from pytest_container.container import container_and_marks_from_pytest_param
+from pytest_container.runtime import OciRuntimeBase
+
+from bci_tester.data import BASE_CONTAINER
+from bci_tester.data import KEA_CONTAINERS
+from bci_tester.runtime_choice import DOCKER_SELECTED
+
+
+@pytest.mark.parametrize("ctr_image", KEA_CONTAINERS)
+def test_kea_dhcp4(
+    container_runtime: OciRuntimeBase,
+    host,
+    pytestconfig: pytest.Config,
+    ctr_image: DerivedContainer,
+) -> None:
+    network_name = "macvlan-network"
+    kea_config_file = "tests/files/kea-dhcp4.conf"
+    with open(kea_config_file, "r") as f:
+        config = json.load(f)
+    subnet = config["Dhcp4"]["subnet4"][0]["subnet"]
+    gateway = config["Dhcp4"]["subnet4"][0]["option-data"][0]["data"]
+    network_create_cmd = f"{container_runtime.runner_binary} network create "
+    if DOCKER_SELECTED or os.getuid() == 0:
+        network_create_cmd += "--driver macvlan "
+    else:
+        network_create_cmd += "--internal "
+    network_create_cmd += (
+        f" --subnet={subnet} --gateway={gateway} {network_name}"
+    )
+    host.check_output(network_create_cmd)
+
+    kea_ctr = DerivedContainer(
+        base=ctr_image,
+        containerfile="COPY tests/files/kea-dhcp4.conf /etc/kea/kea-dhcp4.conf",
+        custom_entry_point="kea-dhcp4",
+        extra_entrypoint_args=["-c", "/etc/kea/kea-dhcp4.conf"],
+        extra_launch_args=[f"--network={network_name}", "--privileged"],
+    )
+
+    dhcp_client_ctr = DerivedContainer(
+        base=container_and_marks_from_pytest_param(BASE_CONTAINER)[0],
+        containerfile="RUN zypper refresh && zypper -n install dhcp-client iproute2 && zypper clean --all",
+        custom_entry_point="/bin/sh",
+        extra_launch_args=[f"--network={network_name}", "--privileged"],
+    )
+
+    try:
+        with ContainerLauncher.from_pytestconfig(
+            kea_ctr, container_runtime, pytestconfig
+        ) as kea_launcher, ContainerLauncher.from_pytestconfig(
+            dhcp_client_ctr, container_runtime, pytestconfig
+        ) as cli_launcher:
+            kea_launcher.launch_container()
+            cli_launcher.launch_container()
+
+            cli_con = cli_launcher.container_data.connection
+            default_interface = cli_con.check_output(
+                "ip route show | grep default | cut -d' ' -f5"
+            )
+            client_log = cli_con.run_expect(
+                [0], "dhclient -v " + default_interface
+            ).stderr
+            # Extracts a MAC address (e.g., 00:1A:2B:3C:4D:5E) from a string like 'LPF/eth0/00:1A:2B:3C:4D:5E' using named group 'mac'.
+            mac_pattern = r"LPF/\S+/(?P<mac>[0-9a-fA-F:]+)"
+            mac_match = re.search(mac_pattern, client_log)
+            client_mac = mac_match.group("mac") if mac_match else None
+            assert client_mac is not None
+
+            # Matches "bound to 172.25.1.100" and captures an IPv4 address (e.g., 172.25.1.100) in the 'ip' named group.
+            ip_pattern = r"bound to (?P<ip>\d+\.\d+\.\d+\.\d+)"
+            ip_match = re.search(ip_pattern, client_log)
+            received_ip = ip_match.group("ip") if ip_match else None
+            assert received_ip is not None
+
+            kea_con = kea_launcher.container_data.connection
+            log_lines = kea_con.file("/tmp/kea-dhcp4.log").content_string
+            # Matches DHCP4 lease allocation log entries (e.g., "DHCP4_LEASE_ALLOC [hwtype=1 02:42:ac:19:00:03], cid=[no info], tid=0x7379cf19: lease 172.25.1.100") and captures MAC and IP.
+            pattern = r"DHCP4_LEASE_ALLOC .*?hwtype=1 (?P<mac>[\da-f:]+).*?lease (?P<ip>[\d.]+)"
+            match = re.search(pattern, log_lines)
+            if not match:
+                pytest.fail("IP is not allocated by the kea dhcp server")
+
+            mac = match.group("mac")
+            ip = match.group("ip")
+
+            assert mac == client_mac
+            assert ip == received_ip
+    finally:
+        host.check_output(
+            f"{container_runtime.runner_binary} network rm {network_name}"
+        )

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -48,6 +48,7 @@ from bci_tester.data import GOLANG_CONTAINERS
 from bci_tester.data import GRAFANA_CONTAINERS
 from bci_tester.data import HELM_CONTAINER
 from bci_tester.data import INIT_CONTAINER
+from bci_tester.data import KEA_CONTAINERS
 from bci_tester.data import KERNEL_MODULE_CONTAINER
 from bci_tester.data import KIWI_CONTAINERS
 from bci_tester.data import KUBECTL_CONTAINERS
@@ -280,6 +281,10 @@ IMAGES_AND_NAMES: List[ParameterSet] = [
     + [
         (kubectl_container, "kubectl", ImageType.APPLICATION)
         for kubectl_container in KUBECTL_CONTAINERS
+    ]
+    + [
+        (kea_container, "kea", ImageType.APPLICATION)
+        for kea_container in KEA_CONTAINERS
     ]
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py36,py39,py310,py311,py312,py313}-unit, all, base, cosign, fips, init, dotnet, python, ruby, node, go, openjdk, openjdk_devel, rust, php, busybox, 389ds, metadata, minimal, multistage, repository, doc, lint, check_marks, pcp, distribution, postgres, git, helm, nginx, kernel_module, mariadb, tomcat, spack, gcc, prometheus, grafana, kiwi, postfix, ai, stunnel, kubectl
+envlist = {py36,py39,py310,py311,py312,py313}-unit, all, base, cosign, fips, init, dotnet, python, ruby, node, go, openjdk, openjdk_devel, rust, php, busybox, 389ds, metadata, minimal, multistage, repository, doc, lint, check_marks, pcp, distribution, postgres, git, helm, nginx, kernel_module, mariadb, tomcat, spack, gcc, prometheus, grafana, kiwi, postfix, ai, stunnel, kubectl, kea
 skip_missing_interpreters = True
 
 [common]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->

[CI:TOXENVS] kea
