### PR TITLE
Switch kiwi testing to sp6

### DIFF
--- a/tests/test_kiwi.py
+++ b/tests/test_kiwi.py
@@ -73,7 +73,7 @@ def test_kiwi_create_image(
 
     assert container_per_test.connection.file("kiwi-main/build-tests").exists
 
-    kiwi_cmd = "kiwi-ng system build --description kiwi-main/build-tests/x86/leap/test-image-disk --set-repo obs://openSUSE:Leap:15.5/standard --target-dir /tmp/myimage"
+    kiwi_cmd = "kiwi-ng system build --description kiwi-main/build-tests/x86/leap/test-image-disk --set-repo obs://openSUSE:Leap:15.6/standard --target-dir /tmp/myimage"
     res = container_per_test.connection.run_expect([0, 1], kiwi_cmd)
     if res.rc == 1 and selinux_status() == "enforcing":
         pytest.xfail(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
