### PR TITLE
Update helm version to the latest release to test new golang-openssl

### DIFF
--- a/tests/test_go.py
+++ b/tests/test_go.py
@@ -68,7 +68,7 @@ def test_build_kured(auto_container_per_test, container_git_clone):
     [
         GitRepositoryBuild(
             repository_url="https://github.com/helm/helm.git",
-            repository_tag="v3.15.1",
+            repository_tag="v3.16.4",
             build_command="env GOMAXPROCS=2 make build test-unit",
         ).to_pytest_param(),
     ],
@@ -79,10 +79,6 @@ def test_build_helm(auto_container_per_test, container_git_clone):
     container with :command:`make` pre-installed.
 
     """
-
-    go_version = auto_container_per_test.connection.check_output("go version")
-    if "go1.20" in go_version or "go1.21" in go_version:
-        pytest.skip("Helm requires Go >= 1.22")
 
     auto_container_per_test.connection.check_output(
         container_git_clone.test_command


### PR DESCRIPTION
helm main branch is now helm 4 which dropped support for go older than 1.23

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
