### PR TITLE
Uninstall conflicting python3-packaging

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -208,6 +208,7 @@ jobs:
           python-version: "3.x"
       - name: Install tox
         run: |
+          sudo apt-get remove python3-packaging
           sudo apt-get install python3-pip
           python3 --version
           python3 -m pip install tox


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
