### PR TITLE
Remove python 3.10 from testing

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -586,7 +586,6 @@ PYTHON_WITH_PIPX_CONTAINERS = [
         available_versions=versions,
     )
     for ver, versions in (
-        ("3.10", ["tumbleweed"]),
         ("3.12", ["15.6", "tumbleweed"]),
         ("3.13", ["15.7", "tumbleweed"]),
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,6 @@ markers = [
     'prometheus_2',
     'prometheus_3',
     'python_3.9',
-    'python_3.10',
     'python_3.11',
     'python_3.12',
     'python_3.13',


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
