### PR TITLE
Add test to validate availability of nogroup/nobody

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -53,6 +53,15 @@ def test_iconv_working(auto_container):
 
 
 @pytest.mark.skipif(
+    OS_VERSION in ("15.3", "15.4", "15.5"),
+    reason="unfixed in LTSS codestreams",
+)
+def test_group_nobody_working(auto_container):
+    """Test that nobody group is available in the container (bsc#1212118)."""
+    assert auto_container.connection.check_output("getent group nobody")
+
+
+@pytest.mark.skipif(
     not PODMAN_SELECTED,
     reason="docker size reporting is dependent on underlying filesystem",
 )


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
