### PR TITLE
Make NodeJS 22 available for 15.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -173,6 +173,8 @@ jobs:
           - toxenv: metadata
             os_version: 15.4
           - toxenv: all
+            os_version: "15.6"
+          - toxenv: node
             os_version: "15.7"
           - toxenv: base
             os_version: "15.7"

--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -572,7 +572,7 @@ NODEJS_20_CONTAINER = create_BCI(
 
 NODEJS_22_CONTAINER = create_BCI(
     build_tag="bci/nodejs:22",
-    available_versions=["tumbleweed", "15.7"],
+    available_versions=["tumbleweed", "15.6", "15.7"],
 )
 
 NODEJS_CONTAINERS = [


### PR DESCRIPTION
NodeJS22 should be initially be 15-SP6 based and only later on move to 15-SP7.

[CI:TOXENV] node