### PR TITLE
Use latest tag for alertmanager on Tumbleweed

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -944,7 +944,7 @@ ALERTMANAGER_CONTAINERS = [
     for versions, tag in (
         (("15.6",), "0.26"),
         (("15.7",), "0.26"),
-        (("tumbleweed",), "0.27"),
+        (("tumbleweed",), "latest"),
     )
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ markers = [
     '389-ds_3.1',
     'alertmanager_0.26',
     'alertmanager_0.27',
+    'alertmanager_latest',
     'apache-tomcat_9-openjdk8',
     'apache-tomcat_9-openjdk11',
     'apache-tomcat_9-openjdk17',


### PR DESCRIPTION
Use latest tag for alertmanager on Tumbleweed

Related ticket: https://progress.opensuse.org/issues/176256