### PR TITLE
Decouple check-marks from pre-commit hook

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
           sudo apt update
           sudo apt -y install tox
       - name: Test formatting with ruff & check the markers
-        run: ./pre-commit.sh
+        run: ./pre-commit-full.sh
 
   gentestmatrix:
     name: Generate test matrix

--- a/README.rst
+++ b/README.rst
@@ -169,13 +169,10 @@ Adding the pre-commit hook
 
 You can setup the :file:`pre-commit.sh` script as a pre-commit hook in git, so
 that it runs each time before a commit is created. The script exits with a
-non-zero status on either of the most common mistakes:
+non-zero status when the desired formatting is not applied.
 
-1. :command:`ruff` formating not applied
-
-2. A new container has been added or a version has been toggled, but the
-   respective marker in :file:`pyproject.toml` is missing
-
+The :file:`pre-commit-full.sh` script in addition also checks if any container
+marker in :file:`pyproject.toml` is missing. This checks takes some time.
 
 To install the hook, execute the following commands from the top level project
 directory:
@@ -183,6 +180,6 @@ directory:
 .. code-block:: shell-session
 
     $ pushd .git/hooks/
-    $ ln -s ../../pre-commit.sh pre-commit
+    $ ln -s ../../pre-commit.sh pre-commit   # use `pre-commit-full.sh` to also check container marks
     $ popd
 

--- a/pre-commit-full.sh
+++ b/pre-commit-full.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+tox -e format -- --check
+
+for OS_VERSION in "15.3" "15.4" "15.5" "15.6" "15.6-ai" "15.7" "16.0" "tumbleweed"; do
+    export OS_VERSION
+    tox -e check_marks
+done

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,10 +1,3 @@
-#!/bin/bash
-
-set -e
+#!/bin/bash -e
 
 tox -e format -- --check
-
-for OS_VERSION in "15.3" "15.4" "15.5" "15.6" "15.6-ai" "15.7" "16.0" "tumbleweed"; do
-    export OS_VERSION
-    tox -e check_marks
-done


### PR DESCRIPTION
The check-mark test takes a long time. This commit decouples it and gives the suer the option to only do the formatting or also the check mark test in in the pre-commit hook.

* Follow-up of https://github.com/SUSE/BCI-tests/pull/734