### PR TITLE
Softail size limit on Tumbleweed

### DIFF
--- a/tests/test_minimal.py
+++ b/tests/test_minimal.py
@@ -46,10 +46,15 @@ def test_minimal_image_size(container, container_runtime):
     container_size = container_runtime.get_image_size(
         container.image_url_or_id
     ) // (1024 * 1024)
-    assert (
-        container_size
-        <= minimal_container_max_size[LOCALHOST.system_info.arch]
-    )
+    if container_size > minimal_container_max_size[LOCALHOST.system_info.arch]:
+        if OS_VERSION in ("tumbleweed",):
+            pytest.xfail(
+                "Tumbleweed Minimal image exceeds limit (boo#1236736)"
+            )
+        else:
+            pytest.fail(
+                "Container size f{container_size} exceeds f{minimal_container_max_size[LOCALHOST.system_info.arch]} MiB"
+            )
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Softfail the size limit test on Tumbleweed due to https://bugzilla.opensuse.org/show_bug.cgi?id=1236736 until it it fixed.

* Verification run: https://openqa.opensuse.org/tests/4854579#step/_root_BCI-tests_minimal_/1

[CI:TOXENVS] minimal