### PR TITLE
Accomodate for size increase of openssl and glibc on SP7/ppc64le

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -112,7 +112,7 @@ def test_base_size(container: ContainerData, container_runtime):
         base_container_max_size: Dict[str, int] = {
             "x86_64": 121,
             "aarch64": 135,
-            "ppc64le": 157,
+            "ppc64le": 159,
             "s390x": 122,
         }
     elif OS_VERSION in ("15.6",):


### PR DESCRIPTION
These binaries went multiple megabytes larger thanks to jsc#PED-11850

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
