### PR TITLE
Expand bci-base to 101 MB for 16.0/x86_64

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -103,7 +103,7 @@ def test_base_size(container: ContainerData, container_runtime):
         }
     elif OS_VERSION in ("16.0",):
         base_container_max_size: Dict[str, int] = {
-            "x86_64": 100,
+            "x86_64": 101,
             "aarch64": 126,
             "ppc64le": 138,
             "s390x": 99,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
