### PR TITLE
switch ollama testing to more stable tag

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -1009,7 +1009,7 @@ GRAFANA_CONTAINERS = [
 ]
 
 OLLAMA_CONTAINER = create_BCI(
-    build_tag=f"{SAC_CONTAINER_PREFIX}/ollama:0.5",
+    build_tag=f"{SAC_CONTAINER_PREFIX}/ollama:0",
     bci_type=ImageType.SAC_APPLICATION,
     available_versions=["15.6-ai"],
     forwarded_ports=[PortForwarding(container_port=11434)],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ markers = [
     'openjdk-devel_17',
     'openjdk-devel_21',
     'openjdk-devel_23',
-    'ollama_0.5',
+    'ollama_0',
     'open-webui_0.3',
     'pcp_5',
     'pcp_6',


### PR DESCRIPTION
The AI team decided to remove the 0.5 rolling tag in favor of a "0" tag instead.

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
