### PR TITLE
Test for "ping" working in the busybox container (bsc#1239176)

### DIFF
--- a/tests/test_busybox.py
+++ b/tests/test_busybox.py
@@ -92,6 +92,18 @@ def test_base32_64(auto_container):
     )
 
 
+@pytest.mark.skipif(
+    OS_VERSION in ("15.6", "15.7"),
+    reason="supporting rootless ping is considered a feature and ECO still pending.",
+)
+def test_ping(auto_container):
+    """Ensure ping command works in a busybox container"""
+    assert (
+        "--- www.suse.com ping statistics"
+        in auto_container.connection.check_output("ping -4 -c 2 www.suse.com")
+    )
+
+
 @pytest.mark.parametrize(
     "container_per_test", [BUSYBOX_CONTAINER], indirect=True
 )


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
