### PR TITLE
Update Open-WebUI tag to 0.5

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -1016,7 +1016,7 @@ OLLAMA_CONTAINER = create_BCI(
 )
 
 OPENWEBUI_CONTAINER = create_BCI(
-    build_tag=f"{SAC_CONTAINER_PREFIX}/open-webui:0.3",
+    build_tag=f"{SAC_CONTAINER_PREFIX}/open-webui:0.5",
     bci_type=ImageType.SAC_APPLICATION,
     available_versions=["15.6-ai"],
     forwarded_ports=[PortForwarding(container_port=8080)],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ markers = [
     'openjdk-devel_21',
     'openjdk-devel_23',
     'ollama_0',
-    'open-webui_0.3',
+    'open-webui_0.5',
     'pcp_5',
     'pcp_6',
     'php_8',


### PR DESCRIPTION
Update the tag for open-webui to 0.5

* Related failures: e.g. https://openqa.suse.de/tests/17011027#step/bci_test_podman/32