### PR TITLE
Drop SUSE AppCollection specific containers from testing

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -603,16 +603,6 @@ PYTHON_CONTAINERS = PYTHON_WITH_PIPX_CONTAINERS + [
     )
 ]
 
-# Python containers on SUSE Application Collection
-SAC_PYTHON_CONTAINERS = [
-    create_BCI(
-        build_tag=f"{SAC_CONTAINER_PREFIX}/python:{ver}",
-        available_versions=versions,
-        bci_type=ImageType.SAC_LANGUAGE_STACK,
-    )
-    for ver, versions in (("3.9", ["15.6"]), ("3.11", ["15.6"]))
-]
-
 RUBY_25_CONTAINER = create_BCI(
     build_tag="bci/ruby:2.5", available_versions=["15.6"]
 )
@@ -755,15 +745,12 @@ MARIADB_CLIENT_CONTAINERS = [
 POSTFIX_CONTAINERS = [
     create_BCI(
         build_tag=f"{SAC_CONTAINER_PREFIX}/postfix:{postfix_ver}",
-        bci_type=ImageType.SAC_APPLICATION,
+        bci_type=ImageType.APPLICATION,
         available_versions=os_versions,
         forwarded_ports=[PortForwarding(container_port=25)],
         extra_environment_variables={"SERVER_HOSTNAME": "localhost"},
     )
-    for postfix_ver, os_versions in (
-        (3.8, ["15.6"]),
-        ("3.10", ["tumbleweed"]),
-    )
+    for postfix_ver, os_versions in (("3.10", ["tumbleweed"]),)
 ]
 
 POSTGRES_PASSWORD = "n0ts3cr3t"
@@ -896,15 +883,6 @@ GCC_CONTAINERS = [
 
 APACHE_TOMCAT_10_CONTAINERS = [
     create_BCI(
-        build_tag=f"{SAC_CONTAINER_PREFIX}/apache-tomcat:10.1-openjdk{openjdk_version}",
-        bci_type=ImageType.SAC_APPLICATION,
-        available_versions=("15.6",),
-        forwarded_ports=[PortForwarding(container_port=8080)],
-        container_user="tomcat",
-    )
-    for openjdk_version in (21, 17, 11)
-] + [
-    create_BCI(
         build_tag=f"{APP_CONTAINER_PREFIX}/apache-tomcat:10.1-openjdk{openjdk_version}",
         bci_type=ImageType.APPLICATION,
         available_versions=("tumbleweed",),
@@ -914,15 +892,6 @@ APACHE_TOMCAT_10_CONTAINERS = [
 ]
 
 APACHE_TOMCAT_9_CONTAINERS = [
-    create_BCI(
-        build_tag=f"{SAC_CONTAINER_PREFIX}/apache-tomcat:9-openjdk{openjdk_version}",
-        bci_type=ImageType.SAC_APPLICATION,
-        available_versions=("15.6",),
-        forwarded_ports=[PortForwarding(container_port=8080)],
-        container_user="tomcat",
-    )
-    for openjdk_version in (21, 17, 11, 8)
-] + [
     create_BCI(
         build_tag=f"{SAC_CONTAINER_PREFIX}/apache-tomcat:9-openjdk{openjdk_version}",
         bci_type=ImageType.APPLICATION,
@@ -1077,7 +1046,6 @@ CONTAINERS_WITH_ZYPPER = (
     + PCP_CONTAINERS
     + PROMETHEUS_CONTAINERS
     + PYTHON_CONTAINERS
-    + SAC_PYTHON_CONTAINERS
     + RUBY_CONTAINERS
     + RUST_CONTAINERS
     + SPACK_CONTAINERS
@@ -1178,7 +1146,6 @@ else:
         + OPENJDK_CONTAINERS
         + PCP_CONTAINERS
         + PYTHON_CONTAINERS
-        + SAC_PYTHON_CONTAINERS
         + RUBY_CONTAINERS
         + RUST_CONTAINERS
         + SPACK_CONTAINERS

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -86,7 +86,6 @@ from bci_tester.data import PYTHON_CONTAINERS
 from bci_tester.data import PYTORCH_CONTAINER
 from bci_tester.data import RUBY_CONTAINERS
 from bci_tester.data import RUST_CONTAINERS
-from bci_tester.data import SAC_PYTHON_CONTAINERS
 from bci_tester.data import SPACK_CONTAINERS
 from bci_tester.data import STUNNEL_CONTAINER
 from bci_tester.data import TOMCAT_CONTAINERS
@@ -172,10 +171,6 @@ IMAGES_AND_NAMES: List[ParameterSet] = [
     + [(c, "nodejs", ImageType.LANGUAGE_STACK) for c in NODEJS_CONTAINERS]
     + [(c, "python", ImageType.LANGUAGE_STACK) for c in PYTHON_CONTAINERS]
     + [(c, "ruby", ImageType.LANGUAGE_STACK) for c in RUBY_CONTAINERS]
-    + [
-        (c, "python", ImageType.SAC_LANGUAGE_STACK)
-        for c in SAC_PYTHON_CONTAINERS
-    ]
     + [(c, "base-fips", ImageType.OS) for c in BASE_FIPS_CONTAINERS]
     + [
         (container_pcp, "pcp", ImageType.APPLICATION)
@@ -183,7 +178,7 @@ IMAGES_AND_NAMES: List[ParameterSet] = [
     ]
     + [(kiwi, "kiwi", ImageType.LANGUAGE_STACK) for kiwi in KIWI_CONTAINERS]
     + [
-        (tomcat_ctr, "apache-tomcat", ImageType.SAC_APPLICATION)
+        (tomcat_ctr, "apache-tomcat", ImageType.APPLICATION)
         for tomcat_ctr in TOMCAT_CONTAINERS
     ]
     + [
@@ -219,7 +214,7 @@ IMAGES_AND_NAMES: List[ParameterSet] = [
         for mariab_client_container in MARIADB_CLIENT_CONTAINERS
     ]
     + [
-        (postfix_container, "postfix", ImageType.SAC_APPLICATION)
+        (postfix_container, "postfix", ImageType.APPLICATION)
         for postfix_container in POSTFIX_CONTAINERS
     ]
     + [

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -17,7 +17,6 @@ from pytest_container.runtime import get_selected_runtime
 from bci_tester.data import OS_VERSION
 from bci_tester.data import PYTHON_CONTAINERS
 from bci_tester.data import PYTHON_WITH_PIPX_CONTAINERS
-from bci_tester.data import SAC_PYTHON_CONTAINERS
 from bci_tester.runtime_choice import PODMAN_SELECTED
 
 BCDIR = "/tmp/"
@@ -29,7 +28,7 @@ PORT1 = 8123
 
 
 #: Base containers under test, input of auto_container fixture
-CONTAINER_IMAGES = PYTHON_CONTAINERS + SAC_PYTHON_CONTAINERS
+CONTAINER_IMAGES = PYTHON_CONTAINERS
 
 
 #: Derived containers with the python http.server as CMD and a HEALTHCHECK


### PR DESCRIPTION
Keeping the test infrastructure in tact in case it gets revisited.

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
