### PR TITLE
Fix OS_PRETTY_NAME for SLE 16

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -125,7 +125,7 @@ else:
         (
             f"SUSE Linux Enterprise Server {OS_MAJOR_VERSION} SP{OS_SP_VERSION}"
             if OS_MAJOR_VERSION == 15
-            else f"SUSE Linux Enterprise Server {OS_MAJOR_VERSION}.{OS_SP_VERSION}"
+            else f"SUSE Linux {OS_MAJOR_VERSION}.{OS_SP_VERSION}"
         ),
     )
 


### PR DESCRIPTION
See https://confluence.suse.com/pages/viewpage.action?pageId=1749942754

[CI:TOXENVS] all