### PR TITLE
Switch to stable/oldstable for kubectl related images

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -841,14 +841,6 @@ NGINX_CONTAINER = create_BCI(
     forwarded_ports=[PortForwarding(container_port=80)],
 )
 
-_KUBECTL_VERSION_OS_MATRIX: Tuple[Tuple[str, Tuple[str, ...]], ...] = (
-    ("1.28", ("15.6", "15.7")),
-    ("1.30", ("15.7",)),
-    ("1.30", ("tumbleweed",)),
-    ("1.31", ("tumbleweed",)),
-    ("1.32", ("tumbleweed",)),
-)
-
 KUBECTL_CONTAINERS = [
     create_BCI(
         build_tag=f"{APP_CONTAINER_PREFIX}/kubectl:{kubectl_ver}",
@@ -856,7 +848,13 @@ KUBECTL_CONTAINERS = [
         available_versions=os_versions,
         custom_entry_point="/bin/sh",
     )
-    for kubectl_ver, os_versions in _KUBECTL_VERSION_OS_MATRIX
+    for kubectl_ver, os_versions in (
+        ("oldstable", ("15.6", "15.7")),
+        ("stable", ("15.6", "15.7")),
+        ("1.30", ("tumbleweed",)),
+        ("1.31", ("tumbleweed",)),
+        ("1.32", ("tumbleweed",)),
+    )
 ]
 
 _KEA_VERSION_OS_MATRIX: Tuple[Tuple[str, Tuple[str, ...]], ...] = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,8 @@ markers = [
     'kubectl_1.30',
     'kubectl_1.31',
     'kubectl_1.32',
+    'kubectl_oldstable',
+    'kubectl_stable',
     'mariadb_10.11',
     'mariadb_latest',
     'mariadb-client_10.11',


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
