### PR TITLE
Fix fstring

### DIFF
--- a/tests/test_minimal.py
+++ b/tests/test_minimal.py
@@ -53,7 +53,7 @@ def test_minimal_image_size(container, container_runtime):
             )
         else:
             pytest.fail(
-                "Container size f{container_size} exceeds f{minimal_container_max_size[LOCALHOST.system_info.arch]} MiB"
+                f"Container size {container_size} exceeds {minimal_container_max_size[LOCALHOST.system_info.arch]} MiB"
             )
 
 


### PR DESCRIPTION
The fstring for exceeding the size was wrong.

* Related failure: https://openqa.suse.de/tests/17285579#step/_root_BCI-tests_minimal_/1

[CI:TOXENVS] minimal