### PR TITLE
Add GCC 15 image to testing

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -879,6 +879,7 @@ GCC_CONTAINERS = [
     for gcc_version, os_versions in (
         (13, ("tumbleweed",)),
         (14, ("15.6", "15.7", "tumbleweed")),
+        (15, ("16.0", "tumbleweed")),
     )
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ markers = [
     'gcc_7',
     'gcc_13',
     'gcc_14',
+    'gcc_15',
     'git_2.35',
     'git_2.43',
     'git_latest',


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
