### PR TITLE
Adjust for the next SLFO product rename

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -139,7 +139,7 @@ def test_hostnamectl(
     if OS_VERSION == "tumbleweed":
         expected_os = "openSUSE Tumbleweed"
     elif OS_VERSION in ("16.0",):
-        expected_os = "SUSE Linux " + OS_VERSION
+        expected_os = "SUSE Linux Enterprise Server" + OS_VERSION
 
     assert expected_os in hostnamectl["OperatingSystemPrettyName"], (
         "Missing SUSE tag in Operating system"


### PR DESCRIPTION
Fix:

```
E       AssertionError: Missing SUSE tag in Operating system
E       assert 'SUSE Linux 16.0' in 'SUSE Linux Enterprise Server 16.0'
```

Context: https://confluence.suse.com/display/~okir/Another+attempt+at+os-release