### PR TITLE
Add a noop testing for the suse-observability containers

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -1015,6 +1015,20 @@ STUNNEL_CONTAINER = create_BCI(
     available_versions=["15.6", "15.7", "tumbleweed"],
 )
 
+SUSE_AI_OBSERVABILITY_EXTENSION_SETUP = create_BCI(
+    build_tag=f"{SAC_CONTAINER_PREFIX}/suse-ai-observability-extension-setup:1",
+    bci_type=ImageType.SAC_APPLICATION,
+    available_versions=["15.6-ai"],
+    custom_entry_point="/bin/bash",
+)
+
+SUSE_AI_OBSERVABILITY_EXTENSION_RUNTIME = create_BCI(
+    build_tag=f"{SAC_CONTAINER_PREFIX}/suse-ai-observability-extension-runtime:1",
+    bci_type=ImageType.SAC_APPLICATION,
+    available_versions=["15.6-ai"],
+    custom_entry_point="/bin/bash",
+)
+
 VALKEY_CONTAINERS = [
     create_BCI(
         build_tag=f"{APP_CONTAINER_PREFIX}/valkey:{tag}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,6 +161,8 @@ markers = [
     'bci-sle16-kernel-module-devel_16.0',
     'spack_0.23',
     'stunnel_5',
+    'suse-ai-observability-extension-runtime_1',
+    'suse-ai-observability-extension-setup_1',
     'valkey_8.0',
 ]
 

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -10,12 +10,16 @@ from bci_tester.data import MILVUS_CONTAINER
 from bci_tester.data import OLLAMA_CONTAINER
 from bci_tester.data import OPENWEBUI_CONTAINER
 from bci_tester.data import PYTORCH_CONTAINER
+from bci_tester.data import SUSE_AI_OBSERVABILITY_EXTENSION_RUNTIME
+from bci_tester.data import SUSE_AI_OBSERVABILITY_EXTENSION_SETUP
 
 CONTAINER_IMAGES = (
     OLLAMA_CONTAINER,
     OPENWEBUI_CONTAINER,
     MILVUS_CONTAINER,
     PYTORCH_CONTAINER,
+    SUSE_AI_OBSERVABILITY_EXTENSION_RUNTIME,
+    SUSE_AI_OBSERVABILITY_EXTENSION_SETUP,
 )
 
 
@@ -92,3 +96,8 @@ def test_pytorch_health(container):
         "python3.11 -c 'import torch; print(torch.__version__)'"
     )
     container.connection.check_output("git --version")
+
+
+def test_noop_ai_container_test(auto_container):
+    """Skip any testing of the container."""
+    pass


### PR DESCRIPTION
These are kubernetes jobs, we can't really meaningfully test them

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
