### PR TITLE
Adjust tests for openssl 3.4/3.5 changes

### DIFF
--- a/bci_tester/fips.py
+++ b/bci_tester/fips.py
@@ -18,7 +18,7 @@ NONFIPS_DIGESTS: Tuple[str, ...] = (
 # OpenSSL 3.x in Tumbleweed dropped those as they're beyond deprecated
 if OS_VERSION in ("15.3", "15.4", "15.5"):
     NONFIPS_DIGESTS += ("md4", "mdc2")
-elif OS_VERSION in ("16.0", "tumbleweed"):
+elif OS_VERSION in ("16.0",):
     NONFIPS_DIGESTS += ("sha1",)
 
 #: FIPS compliant openssl digests
@@ -37,7 +37,7 @@ FIPS_DIGESTS: Tuple[str, ...] = (
     "shake256",
 )
 
-if OS_VERSION not in ("16.0", "tumbleweed"):
+if OS_VERSION not in ("16.0",):
     FIPS_DIGESTS += ("sha1",)
 
 NULL_DIGESTS: Dict[str, str] = {

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -23,6 +23,7 @@ from bci_tester.fips import host_fips_enabled
 from bci_tester.fips import target_fips_enforced
 from bci_tester.runtime_choice import DOCKER_SELECTED
 from bci_tester.runtime_choice import PODMAN_SELECTED
+from tests.test_fips import digest_xoflen
 from tests.test_fips import openssl_fips_hashes_test_fnct
 
 CONTAINER_IMAGES = [
@@ -192,7 +193,9 @@ def test_openssl_hashes(container):
 
     """
     for digest in ALL_DIGESTS:
-        container.connection.run_expect([0], f"openssl {digest} /dev/null")
+        container.connection.run_expect(
+            [0], f"openssl {digest}{digest_xoflen(digest)} /dev/null"
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_fips.py
+++ b/tests/test_fips.py
@@ -98,6 +98,21 @@ for param in CONTAINERS_WITH_ZYPPER:
     )
 
 
+def digest_xoflen(digest: str) -> str:
+    """return the openssl parameters to set the desired output function length
+    for variable-length hash functions."""
+    param: str = ""
+
+    if OS_VERSION in ("15.3", "15.4", "15.5"):
+        return param
+
+    if digest in ("shake128",):
+        param = " -xoflen 32"
+    elif digest in ("shake256",):
+        param = " -xoflen 64"
+    return param
+
+
 @pytest.mark.parametrize(
     "container_per_test", FIPS_TESTER_IMAGES, indirect=True
 )
@@ -149,7 +164,7 @@ def openssl_fips_hashes_test_fnct(container_per_test: ContainerData) -> None:
 
     for digest in FIPS_DIGESTS:
         dev_null_digest = container_per_test.connection.check_output(
-            f"openssl {digest} /dev/null"
+            f"openssl {digest}{digest_xoflen(digest)} /dev/null"
         )
         assert f"= {NULL_DIGESTS[digest]}" in dev_null_digest, (
             f"unexpected digest of hash {digest}: {dev_null_digest}"


### PR DESCRIPTION
<!--
[CI:TOXENVS] base,fips

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
