### PR TITLE
only mark cpp13 as xfailed if it is actually installed in the container

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -189,10 +189,11 @@ def test_lifecycle(auto_container):
             continue
 
         entry_name, entry_version, entry_date = entry.split(",")
-        if entry_name.startswith("cpp13"):
-            pytest.xfail("https://bugzilla.suse.com/show_bug.cgi?id=1242170")
-
         if entry_name in installed_binaries:
+            if entry_name.startswith("cpp13"):
+                pytest.xfail(
+                    "https://bugzilla.suse.com/show_bug.cgi?id=1242170"
+                )
             if fnmatch.fnmatch(installed_binaries[entry_name], entry_version):
                 support_end = datetime.datetime.strptime(
                     entry_date, "%Y-%m-%d"


### PR DESCRIPTION
Otherwise we're skipping too many tests.

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
