### PR TITLE
Remove obsolete xfail of techpreview label

### DIFF
--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -503,22 +503,7 @@ def test_disturl_can_be_checked_out(
     [
         cont
         for cont in ALL_CONTAINERS
-        if (
-            cont not in L3_CONTAINERS
-            and cont not in ACC_CONTAINERS
-            and cont != BASE_CONTAINER
-        )
-    ]
-    + [
-        pytest.param(
-            BASE_CONTAINER.values,
-            marks=BASE_CONTAINER.marks
-            + [
-                pytest.mark.xfail(
-                    reason="Base container for SLE 15 SP6 is not using the techpreview label (https://build.suse.de/request/show/325200)"
-                )
-            ],
-        )
+        if (cont not in L3_CONTAINERS and cont not in ACC_CONTAINERS)
     ],
     indirect=True,
 )


### PR DESCRIPTION
bci-base has the correct label for ages now and this test was just wasting resources as it was x-failing consistently since bci-base is released and hence l3 supported now

<!--
[CI:TOXENVS] base

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
