### PR TITLE
Add docs about the CI & currently required secrets

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -9,4 +9,5 @@
    :maxdepth: 2
    :caption: Contents:
 
+   setup
    testdoc

--- a/source/setup.rst
+++ b/source/setup.rst
@@ -1,27 +1,58 @@
-CI Setup & Secrets/Credentials
+Secrets/Credentials for the CI
 ==============================
 
-The CI is using github actions to run all or a subset of the tests on each pull
-request next to general sanity checks.
+The following outlines the use of Git Hub secrets to enable larger test coverage
+on each pull request as would otherwise be possible. This is because some check
+combinations require credentials to retrieve otherwise access-protected content.
 
-Some checks require access to paywalled LTSS container images on
-registry.suse.com. These are accessible after logging into the registry using
-the credentials ``REGISTRY_LOGIN_USERNAME`` and ``REGISTRY_LOGIN_PASSWORD``.
+Below is a list of secrets and what they are used for.
 
-.. TODO(dirk):
+Access to `registry.suse.com`
+-----------------------------
 
-To regenerate these credentials, go to scc.suse.com, login and navigate to
-https://scc.suse.com/organizations/460227/dashboard. Create a new **XXX**
-subscription starting with ``INTERNAL-USE-ONLY``. The password is the
-registration code and the username is ``regcode``.
+Some checks require access to SUSE Linux Enterprise Server LTSS container images on
+registry.suse.com. These are accessible after logging into the registry which is automatically
+performed by the ci.yml Git Hub Action. It accesses the following secrets stored for that
+purpose:
 
-.. TODO(dirk):
+* ``REGISTRY_LOGIN_USERNAME``
+* ``REGISTRY_LOGIN_PASSWORD``
+
+These point to mirroring credentials in a BCI testing organization. Please contact the
+BCI team for expanding the configuration of that testing organization.
+
+Access to `dp.apps.rancher.io`
+------------------------------
+
+Some checks require access to `SUSE Application Collection <https://apps.rancher.io/>` container images on
+`dp.apps.rancher.io`. These are accessible after logging into the Application Collection Distribution
+Platform ("DP") which is automatically performed by the ci.yml Git Hub Action. It accesses the following
+secrets stored for that purpose:
+
+* ``APPCO_USERNAME``
+* ``APPCO_PASSWORD``
+
+These point to access token granted after logging into a sufficiently privileged subscription account
+and can be created in the SUSE Application Collection accounts profile page. Please contact the
+BCI team for expanding the configuration of that testing organization and please contact the SUSE Application
+Collection team to get an account created that has sufficiently subscriptions provisioned.
+
+
+Access to SLES repositories
+---------------------------
+
+The tests for LTSS container images require also access to SUSE Linux Enterprise Server repositories
+which are generally access protected. However, the containers are prepared to handle that by embedding
+:command:`container-suseconnect`.
 
 The tests for :command:`container-suseconnect` require a
 :file:`/etc/zypp/credentials.d/SCCcredentials` from a registered SLES host. This
-file is constructed on the CI from the secrets ``SCC_SYSTEM_PASSWORD`` and
-``SCC_SYSTEM_USERNAME``. You can obtain both values by registering a
-``registry.suse.com/bci/bci-base:15.6`` container image via
-:command:`suseconnect --regcode $regcode`. The username and password can then be
-obtained from :file:`/etc/zypp/credentials.d/SCCcredentials` in the container
-image.
+file is currently constructed on the CI from the following GitHub secrets
+
+* ``SCC_SYSTEM_USERNAME``
+* ``SCC_SYSTEM_PASSWORD``
+
+but will in the future be simplified to a plain set of regcodes instead.
+
+SUSE Linux Enterprise Server LTSS Regcodes can be obtained from the BCI testing organization. Please contact the
+BCI team for expanding the configuration of that testing organization.

--- a/source/setup.rst
+++ b/source/setup.rst
@@ -1,0 +1,27 @@
+CI Setup & Secrets/Credentials
+==============================
+
+The CI is using github actions to run all or a subset of the tests on each pull
+request next to general sanity checks.
+
+Some checks require access to paywalled LTSS container images on
+registry.suse.com. These are accessible after logging into the registry using
+the credentials ``REGISTRY_LOGIN_USERNAME`` and ``REGISTRY_LOGIN_PASSWORD``.
+
+.. TODO(dirk):
+
+To regenerate these credentials, go to scc.suse.com, login and navigate to
+https://scc.suse.com/organizations/460227/dashboard. Create a new **XXX**
+subscription starting with ``INTERNAL-USE-ONLY``. The password is the
+registration code and the username is ``regcode``.
+
+.. TODO(dirk):
+
+The tests for :command:`container-suseconnect` require a
+:file:`/etc/zypp/credentials.d/SCCcredentials` from a registered SLES host. This
+file is constructed on the CI from the secrets ``SCC_SYSTEM_PASSWORD`` and
+``SCC_SYSTEM_USERNAME``. You can obtain both values by registering a
+``registry.suse.com/bci/bci-base:15.6`` container image via
+:command:`suseconnect --regcode $regcode`. The username and password can then be
+obtained from :file:`/etc/zypp/credentials.d/SCCcredentials` in the container
+image.


### PR DESCRIPTION
Required for hand-over. Documents the currently used secrets according to my knowledge, but as @dirkmueller  added them all, I'd need further input.

<!--
[CI:TOXENVS] minimal
-->
