### PR TITLE
Add AI tests for released containers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -163,6 +163,12 @@ jobs:
           - toxenv: metadata
             testing_target: ibs-released
             os_version: 15.5
+          - toxenv: ai
+            testing_target: ibs-released
+            os_version: 15.6-ai
+          - toxenv: metadata
+            testing_target: ibs-released
+            os_version: 15.6-ai
           - toxenv: all
             os_version: 15.3
           - toxenv: base
@@ -372,6 +378,17 @@ jobs:
         env:
           REGISTRY_LOGIN_USERNAME: ${{ secrets.REGISTRY_LOGIN_USERNAME }}
           REGISTRY_LOGIN_PASSWORD: ${{ secrets.REGISTRY_LOGIN_PASSWORD }}
+
+      - name: Login to dp.apps.rancher.io as CI user
+        run: |
+          if [ -n "${APPCO_USERNAME}" ]; then
+            echo $APPCO_PASSWORD | docker login -u $APPCO_USERNAME --password-stdin dp.apps.rancher.io
+            echo $APPCO_PASSWORD | podman login -u $APPCO_USERNAME --password-stdin dp.apps.rancher.io
+          fi
+        if: ${{ matrix.testing_target == 'ibs-released' && matrix.os_version == '15.6-ai' }}
+        env:
+          APPCO_USERNAME: ${{ secrets.APPCO_USERNAME }}
+          APPCO_PASSWORD: ${{ secrets.APPCO_PASSWORD }}
 
       - name: setup SCC credentials
         run: |

--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -165,6 +165,7 @@ else:
     else:
         DISTNAME = f"sle-{OS_MAJOR_VERSION}-sp{OS_SP_VERSION}"
 
+    ibs_released = "registry.suse.com"
     ibs_cr_project: str = f"registry.suse.de/suse/{DISTNAME}/update/cr/totest"
     if OS_VERSION.startswith("16"):
         ibs_cr_project = (
@@ -174,6 +175,7 @@ else:
         ibs_cr_project = (
             "registry.suse.de/suse/sle-15-sp6/update/products/ai/totest"
         )
+        ibs_released = "dp.apps.rancher.io"
 
     BASEURL = {
         "obs": f"registry.opensuse.org/devel/bci/{DISTNAME}",
@@ -182,7 +184,7 @@ else:
         "ibs": f"registry.suse.de/suse/{DISTNAME}/update/bci",
         "dso": "registry1.dso.mil/ironbank/suse",
         "ibs-cr": ibs_cr_project,
-        "ibs-released": "registry.suse.com",
+        "ibs-released": ibs_released,
     }[TARGET]
 
 

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -96,8 +96,3 @@ def test_pytorch_health(container):
         "python3.11 -c 'import torch; print(torch.__version__)'"
     )
     container.connection.check_output("git --version")
-
-
-def test_noop_ai_container_test(auto_container):
-    """Skip any testing of the container."""
-    pass


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
