### PR TITLE
Test for consistency in the artifacthub labels

### DIFF
--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -394,6 +394,39 @@ def test_general_labels(
 
 
 @pytest.mark.parametrize(
+    "container",
+    [cont for cont in ALL_CONTAINERS if cont != BASE_CONTAINER],
+    indirect=True,
+)
+def test_artifacthub_urls(container: ContainerData) -> None:
+    """Smoke test checking that the artifacthub.io labelling is passing sanity checks"""
+    labels = container.inspect.config.labels
+
+    assert "io.artifacthub.package.readme-url" in labels, (
+        "readme url missing in labels"
+    )
+    readme_url = urllib.parse.urlparse(
+        labels["io.artifacthub.package.readme-url"]
+    )
+
+    assert readme_url.scheme == "https"
+    assert readme_url.netloc in (
+        "github.com",
+        "build.opensuse.org",
+        "sources.suse.com",
+    ), f"readme-url points to unexpected host {readme_url.netloc}"
+    assert readme_url.port is None
+
+    # for devel projects we pass it as a query
+    path_location = readme_url.query if readme_url.query else readme_url.path
+
+    assert path_location.endswith(".md")
+    assert "/README" in path_location
+    assert "//" not in path_location and "//" not in readme_url.path
+    # TODO(dmllr): add testing for logo-url
+
+
+@pytest.mark.parametrize(
     "container,container_name,container_type",
     IMAGES_AND_NAMES,
     indirect=["container"],


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
