### PR TITLE
Add plumbing for kiosk container testing

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -1052,6 +1052,28 @@ BIND_CONTAINERS = [
     )
 ]
 
+KIOSK_CONTAINERS = [
+    create_BCI(
+        build_tag=f"{APP_CONTAINER_PREFIX}/kiosk/firefox-esr:esr",
+        bci_type=ImageType.APPLICATION,
+        available_versions=_DEFAULT_NONBASE_SLE_VERSIONS,
+        custom_entry_point="/bin/sh",
+    ),
+    create_BCI(
+        build_tag=f"{APP_CONTAINER_PREFIX}/kiosk/pulseaudio:17",
+        bci_type=ImageType.APPLICATION,
+        available_versions=_DEFAULT_NONBASE_SLE_VERSIONS,
+        custom_entry_point="/bin/sh",
+    ),
+    create_BCI(
+        build_tag=f"{APP_CONTAINER_PREFIX}/kiosk/xorg:21",
+        bci_type=ImageType.APPLICATION,
+        available_versions=_DEFAULT_NONBASE_SLE_VERSIONS,
+        custom_entry_point="/bin/sh",
+    ),
+]
+
+
 CONTAINERS_WITH_ZYPPER = (
     [
         BASE_CONTAINER,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ markers = [
     'dotnet-runtime_9.0',
     'dotnet-sdk_8.0',
     'dotnet-sdk_9.0',
+    'firefox-esr_esr',
     'gcc_7',
     'gcc_13',
     'gcc_14',
@@ -142,6 +143,7 @@ markers = [
     'postgres_17',
     'prometheus_2',
     'prometheus_3',
+    'pulseaudio_17',
     'python_3.9',
     'python_3.11',
     'python_3.12',
@@ -164,6 +166,7 @@ markers = [
     'suse-ai-observability-extension-runtime_1',
     'suse-ai-observability-extension-setup_1',
     'valkey_8.0',
+    'xorg_21',
 ]
 
 [tool.ruff]


### PR DESCRIPTION
This allows running minimal testing to have automated container releases.

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
