### PR TITLE
Cache tox setups between runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -217,6 +217,11 @@ jobs:
           command -v ldapwhoami
         if: ${{ matrix.toxenv == '389ds' }}
 
+      - uses: actions/cache@v4
+        with:
+            path: .tox
+            key: tox--${{ hashFiles('tox.ini') }}
+
       - name: Install new podman from OBS
         if: false
         run: |


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
