### PR TITLE
Fix a few linter warnings to keep the score up

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -1206,6 +1206,11 @@ if __name__ == "__main__":
     )
 
     def has_true_skipif(param: ParameterSet) -> bool:
+        """Check if a ParameterSet has a 'skipif' mark with a truthy condition.
+        Returns:
+            True if a 'skipif' mark with a truthy condition is found, False
+            otherwise.
+        """
         for mark in param.marks:
             if mark.name == "skipif" and mark.args and mark.args[0]:
                 return True

--- a/tests/test_bind.py
+++ b/tests/test_bind.py
@@ -1,3 +1,5 @@
+"""Tests for the BCI ISC Bind (DNS) container"""
+
 from datetime import timedelta
 from pathlib import Path
 from typing import Dict
@@ -236,12 +238,12 @@ def test_tmpfiles_d_created(container: ContainerData) -> None:
 
         # directories
         if tp == "d":
-            dir = container.connection.file(path)
-            assert dir.exists
-            assert dir.is_directory
-            assert dir.user == owner
-            assert dir.group == group
-            assert oct(dir.mode) == f"0o{mode}"
+            tmpfile_dir = container.connection.file(path)
+            assert tmpfile_dir.exists
+            assert tmpfile_dir.is_directory
+            assert tmpfile_dir.user == owner
+            assert tmpfile_dir.group == group
+            assert oct(tmpfile_dir.mode) == f"0o{mode}"
 
         # created files
         elif tp == "C":

--- a/tests/test_tomcat.py
+++ b/tests/test_tomcat.py
@@ -49,7 +49,12 @@ def test_tomcat_launches(container: ContainerData) -> None:
 
 @pytest.mark.parametrize("container", TOMCAT_CONTAINERS, indirect=True)
 def test_tomcat_logs(container: ContainerData) -> None:
-    """"""
+    """Verify that Tomcat's startup logs contain expected messages.
+
+    This test checks the container logs after Tomcat has started to ensure
+    that specific log messages related to the server's startup and logging
+    configuration are present.
+    """
     _tomcat_launch_test_fn(container)
     logs = container.read_container_logs()
     assert (


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
