### PR TITLE
Add OpenSSL 1.1 test to 15-SP6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -402,7 +402,7 @@ jobs:
           username=$SCC_CREDENTIAL_USERNAME
           password=$SCC_CREDENTIAL_PASSWORD
           EOF
-        if: ${{ matrix.testing_target == 'ibs-released' || matrix.toxenv == 'fips' }}
+        if: ${{ matrix.testing_target == 'ibs-released' || matrix.toxenv == 'fips' || matrix.toxenv == 'base' }}
         env:
           SCC_CREDENTIAL_USERNAME: ${{ secrets.SCC_SYSTEM_USERNAME }}
           SCC_CREDENTIAL_PASSWORD: ${{ secrets.SCC_SYSTEM_PASSWORD }}


### PR DESCRIPTION
The BCI Base FIPS container for version 15-SP6 has compatibility with both OpenSSL 3 and OpenSSL 1.1, and so the latter must be checked.

For that, we should install `openssl-1_1` from the `Legacy Module 15-SP6`. And repeat the OpenSSL hashes test for it too in 15-SP6

[CI:fips,base]
