### PR TITLE
Drop unused function host_fips_supported()

### DIFF
--- a/bci_tester/fips.py
+++ b/bci_tester/fips.py
@@ -123,18 +123,6 @@ if OS_VERSION != "15.3":
     )
 
 
-def host_fips_supported(
-    fipsfile: str = "/proc/sys/crypto/fips_enabled",
-) -> bool:
-    """Returns a boolean whether FIPS mode is supported on this machine.
-
-    Parameters:
-    fipsfile: path to the file in :file:`/proc` determining whether FIPS mode is enabled
-
-    """
-    return os.path.exists(fipsfile)
-
-
 def host_fips_enabled(fipsfile: str = "/proc/sys/crypto/fips_enabled") -> bool:
     """Returns a boolean indicating whether FIPS mode is enabled on this
     machine.
@@ -143,7 +131,7 @@ def host_fips_enabled(fipsfile: str = "/proc/sys/crypto/fips_enabled") -> bool:
     fipsfile: path to the file in :file:`/proc` determining whether FIPS mode is enabled
 
     """
-    if not host_fips_supported(fipsfile):
+    if not os.path.exists(fipsfile):
         return False
 
     with open(fipsfile, encoding="utf8") as fipsfile_fd:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,19 +1,8 @@
 from pathlib import Path
 
 from bci_tester.fips import host_fips_enabled
-from bci_tester.fips import host_fips_supported
 from bci_tester.selinux import selinux_status
 from bci_tester.util import get_repos_from_zypper_xmlout
-
-
-def test_host_fips_supported(tmp_path):
-    """Check that ``host_fips_supported`` correctly returns True if the fips
-    file exists.
-
-    """
-    fipsfile = tmp_path / "fips"
-    fipsfile.write_text("")
-    assert host_fips_supported(f"{fipsfile}")
 
 
 def test_host_fips_enabled(tmp_path):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
