### PR TITLE
switch to a mirror of dpdk-kmod that isn't constantly down

### DIFF
--- a/tests/test_kernel_module.py
+++ b/tests/test_kernel_module.py
@@ -78,7 +78,8 @@ def test_drbd_builds(container: ContainerData) -> None:
     "container_git_clone",
     [
         GitRepositoryBuild(
-            repository_url="https://dpdk.org/git/dpdk-kmods",
+            # repository_url="https://dpdk.org/git/dpdk-kmods",
+            repository_url="https://github.com/InterfaceMasters/dpdk-kmods.git",
             repository_tag="main",
             build_command="""cd linux/igb_uio/;
                 make KSRC=/usr/src/linux-obj/$(uname -m)/default""",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
