### PR TITLE
Configure kea tests to request a specific ip in the range offered by kea server

### DIFF
--- a/tests/files/kea-dhcp4.conf
+++ b/tests/files/kea-dhcp4.conf
@@ -25,7 +25,7 @@
                 "name": "kea-dhcp4",
                 "output_options": [
                 {
-                    "output": "/tmp/kea-dhcp4.log",
+                    "output": "/var/log/kea/kea-dhcp4.log",
                     "maxsize": 1048576,
                     "maxver": 8
                 }
@@ -36,7 +36,7 @@
                 "name": "kea-dhcp4.packets",
                 "output_options": [
                 {
-                    "output": "/tmp/kea-dhcp4-packets.log",
+                    "output": "/var/log/kea/kea-dhcp4-packets.log",
                     "maxver": 10
                 }
                 ],


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->

Right now kea tests are failing as sometimes the client receives an ip address from an external dhcp server.
To avoid this issue, modified the dhcp client configuration to receive specific ip in the range offered by kea dhcp server.

[CI:TOXENVS] kea
