### PR TITLE
Avoid depending on ftp.suse.com for verification

### DIFF
--- a/tests/test_cosign.py
+++ b/tests/test_cosign.py
@@ -20,6 +20,6 @@ def test_cosign_verify(auto_container, host, container_runtime):
     """Test that we can invoke `cosign verify` on a bci-container."""
     assert "cosign container image signature" in host.check_output(
         f"{container_runtime.runner_binary} run --rm {auto_container.image_url_or_id} "
-        "verify --key https://ftp.suse.com/pub/projects/security/keys/container-key.pem "
+        "verify --key /usr/share/pki/containers/suse-container-key.pem "
         "registry.suse.com/bci/bci-micro:latest"
     )


### PR DESCRIPTION
We finally started embedding the suse signing key in the suse cosign container, so we can just reference it directly.

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
