### PR TITLE
use strptime for python 3.6+

### DIFF
--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -442,9 +442,15 @@ def test_support_end_in_future(
             pytest.skip(
                 reason="SAC containers do not properly define a supportlevel"
             )
-        support_end = datetime.datetime.fromisoformat(
-            labels["com.suse.supportlevel.until"]
-        )
+        try:
+            # python 3.7+
+            support_end: datetime.datetime = datetime.datetime.fromisoformat(
+                labels["com.suse.supportlevel.until"]
+            )
+        except AttributeError:
+            support_end = datetime.datetime.strptime(
+                labels["com.suse.supportlevel.until"], "%Y-%m-%d"
+            )
         assert datetime.datetime.now() < support_end, (
             f"container out of {support_end}"
         )


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
