### PR TITLE
Ai released fetch

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -168,20 +168,22 @@ else:
     else:
         DISTNAME = f"sle-{OS_MAJOR_VERSION}-sp{OS_SP_VERSION}"
 
-    ibs_released = "registry.suse.com"
+    obs_project: str = f"registry.opensuse.org/devel/bci/{DISTNAME}"
+    ibs_released: str = "registry.suse.com"
     ibs_cr_project: str = f"registry.suse.de/suse/{DISTNAME}/update/cr/totest"
     if OS_VERSION.startswith("16"):
         ibs_cr_project = (
             f"registry.suse.de/suse/slfo/products/sles/{DISTNAME}/test"
         )
-    if OS_VERSION == "15.6-ai":
+    elif OS_VERSION == "15.6-ai":
+        obs_project = "registry.suse.de/devel/ai"
         ibs_cr_project = (
             "registry.suse.de/suse/sle-15-sp6/update/products/ai/totest"
         )
         ibs_released = "dp.apps.rancher.io"
 
-    BASEURL = {
-        "obs": f"registry.opensuse.org/devel/bci/{DISTNAME}",
+    BASEURL: str = {
+        "obs": obs_project,
         "factory-totest": "registry.opensuse.org/opensuse/factory/totest",
         "factory-arm-totest": "registry.opensuse.org/opensuse/factory/arm/totest",
         "ibs": f"registry.suse.de/suse/{DISTNAME}/update/bci",
@@ -252,6 +254,8 @@ _IMAGE_TYPE_T = Literal["dockerfile", "kiwi"]
 def _get_repository_name(image_type: _IMAGE_TYPE_T) -> str:
     if TARGET in ("dso", "ibs-released"):
         return ""
+    if OS_VERSION == "15.6-ai" and TARGET in ("ibs", "obs"):
+        return "containers/"
     if OS_VERSION == "15.6-ai" and TARGET == "ibs-cr":
         return "images/"
     if TARGET == "ibs-cr":

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -90,6 +90,7 @@ from bci_tester.data import SPACK_CONTAINERS
 from bci_tester.data import STUNNEL_CONTAINER
 from bci_tester.data import SUSE_AI_OBSERVABILITY_EXTENSION_RUNTIME
 from bci_tester.data import SUSE_AI_OBSERVABILITY_EXTENSION_SETUP
+from bci_tester.data import TARGET
 from bci_tester.data import TOMCAT_CONTAINERS
 from bci_tester.data import VALKEY_CONTAINERS
 from bci_tester.data import ImageType
@@ -493,6 +494,8 @@ def test_disturl(
                 "obs://build.opensuse.org/openSUSE:Factory" in disturl,
             )
         )
+    elif OS_VERSION == "15.6-ai" and TARGET in ("ibs", "obs"):
+        assert "obs://build.suse.de/Devel:AI" in disturl
     elif OS_VERSION == "16.0":
         if baseurl.netloc == "registry.opensuse.org":
             assert (
@@ -686,8 +689,12 @@ def test_reference(
             else f"{name}:{OS_VERSION}"
         )
     else:
-        version = list(version_release.split("-"))[0]
-        ref = f"{name}:{version}"
+        non_release_ref = (
+            version_release.rpartition("-")[0]
+            if "-" in version_release
+            else version_release
+        )
+        ref = f"{name}:{non_release_ref}"
 
     # Skip testing containers that have not yet been released to avoid unnecessary failures
     if not container.container.baseurl.startswith(ref.partition(":")[0]):


### PR DESCRIPTION
the AI-flavor container have a $version-$variant-$release reference tag,
so we were splitting after the first dash while we want to split before the last dash.

Also implement handling of TARGET=obs/ibs for AI