### PR TITLE
run the fips tests in github ci again

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
 
       - id: setmatrix
         run: |
-          set stringified_matrix (tox -l | sed -e '/unit/d' -e '/get_urls/d' -e '/doc/d' -e '/lint/d' -e '/fips/d' -e '/ai/d' | jo -a)
+          set stringified_matrix (tox -l | sed -e '/unit/d' -e '/get_urls/d' -e '/doc/d' -e '/lint/d' -e '/ai/d' | jo -a)
 
           # grep the [CI:TOXENVS] line and print everything after it.
           # the sed call removes additional whitespace after a comma as


### PR DESCRIPTION
They were moved into dedicated workers as part of commit 435f46aaec112f7a432f343c54d483cb0f01bd95 which was then later deleted without reverting the exclusion.

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
