### PR TITLE
Ignore an exit code of 1 in "container-suseconnect lm"

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -611,9 +611,9 @@ def test_container_build_and_repo(container_per_test, host):
             "/usr/lib/zypp/plugins/services/container-suseconnect-zypp"
         ).exists
         and len(
-            container_per_test.connection.check_output(
-                "container-suseconnect lm"
-            ).splitlines()
+            container_per_test.connection.run_expect(
+                [0, 1], "container-suseconnect lm"
+            ).stdout.splitlines()
         )
         > 3
     )


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
