### PR TITLE
Don't create confusing marks

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -372,7 +372,7 @@ def create_BCI(
         else:
             available_versions = list(_DEFAULT_BASE_OS_VERSIONS)
 
-    if available_versions:
+    if available_versions and OS_VERSION not in available_versions:
         marks.append(create_container_version_mark(available_versions))
 
     # only try to grab the mark from the build tag for containers that are


### PR DESCRIPTION
Looking at the container data is really confusing because almost everything has a skipif(False) condition attached to it. we don't have to create it.

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
