### PR TITLE
Skip kiwi --version test on a fips enforcing host (bsc#1243830)

### DIFF
--- a/tests/test_kiwi.py
+++ b/tests/test_kiwi.py
@@ -37,6 +37,10 @@ for kiwi_ctr in KIWI_CONTAINERS:
     )
 
 
+@pytest.mark.xfail(
+    host_fips_enabled(),
+    reason="https://bugzilla.suse.com/show_bug.cgi?id=1243830",
+)
 def test_kiwi_installation(auto_container):
     """check if kiwi package is installed inside the container"""
     assert (


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
