### PR TITLE
enable bci repo tests for SL16

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -57,6 +57,7 @@ ALLOWED_BCI_REPO_OS_VERSIONS = (
     "15.6",
     "15.6-ai",
     "15.7",
+    "16.0",
     "tumbleweed",
 )
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -219,8 +219,8 @@ def test_codestream_lifecycle(container_per_test):
 
 
 @pytest.mark.skipif(
-    OS_VERSION not in ALLOWED_BCI_REPO_OS_VERSIONS,
-    reason="no included BCI repository",
+    not OS_VERSION.startswith("15"),
+    reason="SLE BCI 15.x specific checks for packages",
 )
 @pytest.mark.skipif(
     OS_VERSION == "tumbleweed", reason="No testing for openSUSE"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
