### PR TITLE
Add Java17 testing on SP7

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -563,11 +563,11 @@ OPENJDK_DEVEL_11_CONTAINER = create_BCI(
 )
 OPENJDK_17_CONTAINER = create_BCI(
     build_tag="bci/openjdk:17",
-    available_versions=["tumbleweed"],
+    available_versions=_DEFAULT_NONBASE_OS_VERSIONS,
 )
 OPENJDK_DEVEL_17_CONTAINER = create_BCI(
     build_tag="bci/openjdk-devel:17",
-    available_versions=["tumbleweed"],
+    available_versions=_DEFAULT_NONBASE_OS_VERSIONS,
     custom_entry_point="/bin/sh",
 )
 OPENJDK_21_CONTAINER = create_BCI(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
