### PR TITLE
Update valkey versioning for tumbleweed

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -1079,7 +1079,10 @@ VALKEY_CONTAINERS = [
         available_versions=versions,
         forwarded_ports=[PortForwarding(container_port=6379)],
     )
-    for versions, tag in ((("tumbleweed", "15.6", "15.7"), "8.0"),)
+    for versions, tag in (
+        (("15.6", "15.7"), "8.0"),
+        (("tumbleweed",), "latest"),
+    )
 ]
 
 BIND_CONTAINERS = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,7 @@ markers = [
     'suse-ai-observability-extension-runtime_1',
     'suse-ai-observability-extension-setup_1',
     'valkey_8.0',
+    'valkey_latest',
     'xorg_21',
 ]
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
