### PR TITLE
switch to pypi releases for pytest_container

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # 3.6: SLE15
+        # 3.6: SLE12
         # 3.9: RHEL/Centos/Liberty 9
         # 3.11: Tumbleweed
         # 3.12: Ubuntu 24.04

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ skip_missing_interpreters = True
 [common]
 deps =
     pytest
+    pytest-container >= 0.4.3
     pytest-testinfra
     pytest-xdist ; python_version >= "3.6"
     dataclasses ; python_version < "3.7"
@@ -14,7 +15,6 @@ deps =
     # 8.4.0 is borked: https://github.com/jd/tenacity/issues/471
     tenacity != 8.4.0
     dnspython
-    git+https://github.com/dcermak/pytest_container
     doc: Sphinx
 
 [testenv]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
