### PR TITLE
Fix tests after distribution 3.0 upgrade

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -811,8 +811,14 @@ POSTGRESQL_CONTAINERS = [
     )
 ]
 
+_DISTRIBUTION_VERSION = "latest"
+if OS_VERSION in ("15.7",):
+    _DISTRIBUTION_VERSION = "2.8"
+elif OS_VERSION in ("16.0",):
+    _DISTRIBUTION_VERSION = "3.0"
+
 DISTRIBUTION_CONTAINER = create_BCI(
-    build_tag=f"{APP_CONTAINER_PREFIX}/registry:2.8",
+    build_tag=f"{APP_CONTAINER_PREFIX}/registry:{_DISTRIBUTION_VERSION}",
     bci_type=ImageType.APPLICATION,
     image_type="kiwi",
     forwarded_ports=[PortForwarding(container_port=5000)],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,8 @@ markers = [
     'python_3.6',
     'pytorch_2-nvidia',
     'registry_2.8',
+    'registry_3.0',
+    'registry_latest',
     'ruby_2.5',
     'ruby_3.4',
     'ruby_latest',


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
