### PR TITLE
Enable dind tests for 16

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -300,10 +300,6 @@ DIND_CONTAINER = pytest.param(
 
 
 @pytest.mark.parametrize("container_per_test", [DIND_CONTAINER], indirect=True)
-@pytest.mark.xfail(
-    OS_VERSION in ("16.0",),
-    reason="SLE BCI repository not yet available",
-)
 @pytest.mark.skipif(
     not DOCKER_SELECTED,
     reason="Docker in docker can only be tested when using the docker runtime",


### PR DESCRIPTION
The BCI repo is now available, so the xfail is no longer a failure.

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
