### PR TITLE
Fix expected updates URL for SLE 16.0

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -237,8 +237,15 @@ if BCI_DEVEL_REPO is None:
         BCI_DEVEL_REPO = "http://download.opensuse.org/tumbleweed/repo/oss/"
     else:
         # from SLE 15 SP6 onward we use the unauthenticated CDN
-        cdn_prefix = "public-dl" if OS_SP_VERSION >= 6 else "updates"
-        BCI_DEVEL_REPO = f"https://{cdn_prefix}.suse.com/SUSE/Products/SLE-BCI/{OS_MAJOR_VERSION}-SP{OS_SP_VERSION}/{LOCALHOST.system_info.arch}/product/"
+        cdn_prefix = (
+            "public-dl"
+            if OS_SP_VERSION >= 6 or OS_MAJOR_VERSION > 15
+            else "updates"
+        )
+        if OS_MAJOR_VERSION > 15:
+            BCI_DEVEL_REPO = f"https://{cdn_prefix}.suse.com/SUSE/Products/SLE-BCI/{OS_MAJOR_VERSION}.{OS_SP_VERSION}/{LOCALHOST.system_info.arch}/product/"
+        else:
+            BCI_DEVEL_REPO = f"https://{cdn_prefix}.suse.com/SUSE/Products/SLE-BCI/{OS_MAJOR_VERSION}-SP{OS_SP_VERSION}/{LOCALHOST.system_info.arch}/product/"
     _BCI_REPLACE_REPO_CONTAINERFILE = ""
 else:
     bci_repo_path = f"/etc/zypp/repos.d/{BCI_REPO_NAME}.repo"


### PR DESCRIPTION
Fix expected updates URL for SLE 16.0, which dropped the concept of a Service Pack.

Related ticket: https://progress.opensuse.org/issues/176964

Fixes CI failure:

https://github.com/SUSE/BCI-tests/actions/runs/16009560314/job/45164070001?pr=867

```
FAILED tests/test_all.py::test_container_build_and_repo[local-bci/gcc:15 from registry.opensuse.org/devel/bci/16.0/containerfile/bci/gcc:15] - AssertionError: assert 'https://public-dl.suse.com/SUSE/Products/SLE-BCI/16.0/x86_64/product/' == 'https://updates.suse.com/SUSE/Products/SLE-BCI/16-SP0/x86_64/product/'
  - https://updates.suse.com/SUSE/Products/SLE-BCI/16-SP0/x86_64/product/
  ?          ^ ^^^^                                  ^^^
  + https://public-dl.suse.com/SUSE/Products/SLE-BCI/16.0/x86_64/product/
```

Other failures are due to non-existent `registry.opensuse.org/devel/bci/tumbleweed/images/opensuse/registry:2.8`