### PR TITLE
Switch fetching of hello example to opensuse

### DIFF
--- a/tests/test_gcc.py
+++ b/tests/test_gcc.py
@@ -9,11 +9,11 @@ from bci_tester.data import GCC_CONTAINERS
 
 CONTAINER_IMAGES = GCC_CONTAINERS
 
-_HELLO_VERSION = "2.12.1"
+_HELLO_VERSION = "2.12.2"
 
 CONTAINERFILE_HELLO = f"""
 WORKDIR /src
-RUN curl -sLO https://ftpmirror.gnu.org/hello/hello-{_HELLO_VERSION}.tar.gz && \\
+RUN curl -sLO https://api.opensuse.org/public/source/openSUSE:Factory/hello/hello-{_HELLO_VERSION}.tar.gz?rev=91eb2953d334a8b971c512dccb0c6df3 && \\
     tar --no-same-permissions --no-same-owner -xf hello-{_HELLO_VERSION}.tar.gz && \\
     cd hello-{_HELLO_VERSION} && \\
     ./configure && \\


### PR DESCRIPTION
this is one of the most frequently failing test because of occassional instability of ftpmirror.gnu.org. use our own hosted infrastructure instead

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
