### PR TITLE
Remove xfail for bsc#1243830

### DIFF
--- a/tests/test_kiwi.py
+++ b/tests/test_kiwi.py
@@ -37,10 +37,6 @@ for kiwi_ctr in KIWI_CONTAINERS:
     )
 
 
-@pytest.mark.xfail(
-    host_fips_enabled(),
-    reason="https://bugzilla.suse.com/show_bug.cgi?id=1243830",
-)
 def test_kiwi_installation(auto_container):
     """check if kiwi package is installed inside the container"""
     assert (


### PR DESCRIPTION
Remove xfail for https://bugzilla.suse.com/show_bug.cgi?id=1243830 which is now fixed.

Failed test:
https://openqa.suse.de/tests/18382621#step/_root_BCI-tests_kiwi_/2