### PR TITLE
Fix kea test not working on openQA

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,7 @@ passenv =
     TARGET
     TESTINFRA_LOGGING
     USER
+    USE_MACVLAN_DUMMY
     XDG_CONFIG_HOME
     XDG_RUNTIME_DIR
 commands =


### PR DESCRIPTION
Fix for kea test not working on openQA
[Before](https://openqa.suse.de/tests/18393329#step/_root_BCI-tests_kea_/1)
[After](https://openqa.suse.de/tests/18405630)