### PR TITLE
Fix ruby 2.x tests failing on multi_json requiring a newer ruby

### DIFF
--- a/tests/test_ruby.py
+++ b/tests/test_ruby.py
@@ -38,14 +38,20 @@ def test_lang_set(auto_container):
         ),
         (
             # bsc#1203692
-            "sqlite3" if OS_VERSION == "tumbleweed" else "sqlite3 -v 1.4.0"
+            "sqlite3 -v 1.4.0"
+            if OS_VERSION in ("15.5", "15.6", "15.7")
+            else "sqlite3"
         ),
         "rspec-expectations",
         "diff-lcs",
         "rspec-mocks",
         "rspec-support",
         "rspec",
-        "multi_json",
+        (
+            "multi_json -v 1.15.0"
+            if OS_VERSION in ("15.5", "15.6", "15.7")
+            else "multi_json"
+        ),
         "rack",
         "rake",
         "i18n",


### PR DESCRIPTION
Without this, tests fail with:

    The last version of multi_json (>= 0) to support your Ruby &
    RubyGems was 1.15.0. Try installing it with `gem install
    multi_json -v 1.15.0`\n\tmulti_json requires Ruby version
    >= 3.2. The current ruby version is 2.5.0.

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
