### PR TITLE
Add test for pipx with non-root user

### DIFF
--- a/tests/trainers/flask_hello_example.py
+++ b/tests/trainers/flask_hello_example.py
@@ -1,0 +1,8 @@
+from flask import Flask
+
+app = Flask(__name__)
+
+
+@app.route("/")
+def hello():
+    return "Hello from Flask!"


### PR DESCRIPTION
pipx requires its setup to be done as root, but it can run as a regular user once the setup is completed.

This test ensures that a pipx container application works as a non-root user.

[CI:TOXENVS] python,minimal
