### PR TITLE
Add SLE 16.0 to RELEASED_SLE_VERSIONS

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -80,6 +80,7 @@ RELEASED_SLE_VERSIONS = (
     "15.6-ai",
     "15.6-spr",
     "15.7",
+    "16.0",
 )
 
 # List the LTSS versions of SLE


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/187371
Verification run: https://openqa.suse.de/tests/18803616