### PR TITLE
Skip testing of bci eula only on ltss distributions

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -44,6 +44,7 @@ from bci_tester.data import OS_PRETTY_NAME
 from bci_tester.data import OS_VERSION
 from bci_tester.data import OS_VERSION_ID
 from bci_tester.data import PCP_CONTAINERS
+from bci_tester.data import RELEASED_LTSS_VERSIONS
 from bci_tester.data import RELEASED_SLE_VERSIONS
 from bci_tester.data import ZYPP_CREDENTIALS_DIR
 from bci_tester.util import get_repos_from_connection
@@ -516,7 +517,7 @@ def test_bci_eula_is_correctly_available(container: ContainerData) -> None:
     # are running tests for the bci-* base os containers which are not LTSS
     # and still contain a BCI license. As they are out of maintenance, we
     # need to ignore them
-    if OS_VERSION in RELEASED_SLE_VERSIONS:
+    if OS_VERSION in RELEASED_LTSS_VERSIONS:
         if container.container in (
             BASE_CONTAINER.values[0],
             INIT_CONTAINER.values[0],


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
