### PR TITLE
xfail the s390x specific test for now to be able to release a bci-bas…

### DIFF
--- a/tests/test_fips.py
+++ b/tests/test_fips.py
@@ -378,6 +378,10 @@ def test_gpgconf_binary(container_per_test: ContainerData) -> None:
 @pytest.mark.skipif(
     OS_VERSION in ("15.3",), reason="FIPS 140-3 not supported on 15.3"
 )
+@pytest.mark.xfail(
+    OS_VERSION in ("16.0",),
+    reason="https://bugzilla.suse.com/show_bug.cgi?id=1246541",
+)
 @pytest.mark.parametrize(
     "container_per_test", FIPS_TESTER_IMAGES, indirect=True
 )


### PR DESCRIPTION
…e-fips container

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
