### PR TITLE
Disable skipping of FIPS test for 15-SP6

### DIFF
--- a/bci_tester/fips.py
+++ b/bci_tester/fips.py
@@ -100,12 +100,8 @@ NONFIPS_GCRYPT_DIGESTS: Tuple[str, ...] = (
     "md5",
 )
 
-if OS_VERSION != "15.3":
-    NONFIPS_GCRYPT_DIGESTS += ("sm3",)
-
 #: FIPS compliant gcrypt digests
 FIPS_GCRYPT_DIGESTS: Tuple[str, ...] = (
-    "sha1",
     "sha224",
     "sha256",
     "sha384",
@@ -121,6 +117,14 @@ if OS_VERSION != "15.3":
         "sha512_224",
         "sha512_256",
     )
+    NONFIPS_GCRYPT_DIGESTS += ("sm3",)
+
+
+# sha1 is non-FIPS in 15.6
+if OS_VERSION == "15.6":
+    NONFIPS_GCRYPT_DIGESTS += ("sha1",)
+else:
+    FIPS_GCRYPT_DIGESTS += ("sha1",)
 
 
 def host_fips_enabled(fipsfile: str = "/proc/sys/crypto/fips_enabled") -> bool:

--- a/tests/files/fips-test-gcrypt.c
+++ b/tests/files/fips-test-gcrypt.c
@@ -31,6 +31,11 @@ int main(int argc, char *argv[]) {
         fprintf(stderr, "Unknown message digest %s\n", argv[1]);
         return ret_code;
     }
+    // check if the algorithm is FIPS compliant to the service indicator
+    if (gcry_control(GCRYCTL_FIPS_SERVICE_INDICATOR_MD, algo) != GPG_ERR_NO_ERROR) {
+        fprintf(stderr, "Algorithm %s is not FIPS compliant\n", argv[1]);
+        return ret_code;
+    }
 
     if (gcry_md_open(&md_hd, algo, GCRY_MD_FLAG_SECURE) != 0) {
         fprintf(stderr, "Failed to create hash context\n");

--- a/tests/test_fips.py
+++ b/tests/test_fips.py
@@ -343,21 +343,14 @@ def test_gcrypt_binary(container_per_test: ContainerData) -> None:
 
     for digest in NONFIPS_GCRYPT_DIGESTS:
         non_fips_call = c.run_expect([0, 1], f"/bin/fips-test-gcrypt {digest}")
-        if non_fips_call.rc != 1 and non_fips_call.stdout.strip().startswith(
-            "Digest is: "
-        ):
-            if OS_VERSION == "15.6" and digest == "md5":
-                pytest.xfail(
-                    "libgcrypt successfully calculates md5 digest in FIPS mode, bsc#1229903"
-                )
 
-            pytest.xfail(
-                "libgcrypt mistakenly calculates message digests for Non FIPS algorithms, bsc#1229856"
-            )
+        expected_msg = (
+            "Failed to create hash context",
+            f"Algorithm {digest} is not FIPS compliant",
+        )
 
-        assert (
-            non_fips_call.rc == 1
-            and "Failed to create hash context" in non_fips_call.stderr
+        assert non_fips_call.rc == 1 and any(
+            msg in non_fips_call.stderr for msg in expected_msg
         ), f"Hash calculation unexpectedly succeeded for {digest}"
 
 


### PR DESCRIPTION
reference ticket: https://progress.opensuse.org/issues/187236

Have the C test program do a proper check for FIPS compliance and output correct error message on failure.

Include also SHA-1 among the deprecated 140-3 algos

Verification runs:
  - https://openqa.suse.de/tests/18931937
  - https://openqa.suse.de/tests/18931938
  - https://openqa.suse.de/tests/18931939