### PR TITLE
URGENT: Use pytest-rerunfailures < 16.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,8 @@ deps =
     pytest-testinfra
     pytest-xdist ; python_version >= "3.6"
     dataclasses ; python_version < "3.7"
-    pytest-rerunfailures
+    # pytest-rerunfailues 16.0 is broken, see poo#188013
+    pytest-rerunfailures < 16.0
     typing_extensions
     requests
     # 8.4.0 is borked: https://github.com/jd/tenacity/issues/471


### PR DESCRIPTION
pytest-rerunfailures 16.0 breaks all test runs that use it, so we need to stay on the previous version for now.

* Ticket reference: https://progress.opensuse.org/issues/188013