### PR TITLE
Revert "Use pytest-rerunfailures < 16.0"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,7 @@ deps =
     pytest-testinfra
     pytest-xdist ; python_version >= "3.6"
     dataclasses ; python_version < "3.7"
-    # pytest-rerunfailues 16.0 is broken, see poo#188013
-    pytest-rerunfailures < 16.0
+    pytest-rerunfailures
     typing_extensions
     requests
     # 8.4.0 is borked: https://github.com/jd/tenacity/issues/471


### PR DESCRIPTION
There is a 16.0.1 release that fixes the incompatibility with xdist.

This reverts commit 2a6155624e442e5d2c0c384bc8c15a05ecf4f3fb.

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
