### PR TITLE
Adjust expected project for metadata tests on 16

### DIFF
--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -632,7 +632,7 @@ def test_disturl(
             )
         else:
             assert (
-                f"obs://build.suse.de/SUSE:SLFO:Products:SLES:16.{OS_SP_VERSION}"
+                f"obs://build.suse.de/SUSE:SLFO:Products:BCI:16.{OS_SP_VERSION}"
                 in disturl
             )
     else:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
