### PR TITLE
Added mariadb migration tests for OS_VERSION 15.7 and 16.0

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -770,6 +770,7 @@ MARIADB_ROOT_PASSWORD = "'88tpw-n!t-s$$cr`t!"
 _MARIADB_VERSION_OS_MATRIX: Tuple[Tuple[str, Tuple[str, ...]], ...] = (
     ("10.11", ("15.6",)),
     ("11.8", ("15.7",)),
+    ("11.8", ("16.0",)),
     ("latest", ("tumbleweed",)),
 )
 

--- a/tests/test_mariadb.py
+++ b/tests/test_mariadb.py
@@ -304,7 +304,7 @@ _DB_ENV = {
 
 @pytest.mark.parametrize("ctr_image", MARIADB_CONTAINERS)
 @pytest.mark.skipif(
-    OS_VERSION not in ("15.6",),
+    OS_VERSION not in ("15.6", "15.7", "16.0"),
     reason="MariaDB upgrade scenario not supported",
 )
 def test_mariadb_upgrade(
@@ -317,9 +317,18 @@ def test_mariadb_upgrade(
     mounts: List[Union[BindMount, ContainerVolume]] = [
         BindMount(host_path=tmp_path, container_path="/var/lib/mysql")
     ]
+    mariadb_old_images = {
+        "15.6": "registry.suse.com/suse/mariadb:10.6",
+        "15.7": "registry.suse.com/suse/mariadb:10.11",
+        "16.0": "registry.suse.com/suse/mariadb:10.11",
+    }
+    # gosu was renamed to idexec from mariadb_version 10.11
+    gosu = "gosu" if OS_VERSION == "15.6" else "idexec"
     mariadb_old = DerivedContainer(
-        base="registry.suse.com/suse/mariadb:10.6",
-        containerfile='RUN set -euo pipefail; head -n -1 /usr/local/bin/gosu > /tmp/gosu;  echo \'exec setpriv --pdeathsig=keep --reuid="$u" --regid="$u" --clear-groups -- "$@"\' >> /tmp/gosu;  mv /tmp/gosu /usr/local/bin/gosu; chmod +x /usr/local/bin/gosu',
+        base=mariadb_old_images.get(
+            OS_VERSION, "registry.suse.com/suse/mariadb:10.6"
+        ),
+        containerfile=f'RUN set -euo pipefail; head -n -1 /usr/local/bin/{gosu} > /tmp/{gosu};  echo \'exec setpriv --pdeathsig=keep --reuid="$u" --regid="$u" --clear-groups -- "$@"\' >> /tmp/{gosu};  mv /tmp/{gosu} /usr/local/bin/{gosu}; chmod +x /usr/local/bin/{gosu}',
         volume_mounts=mounts,
         extra_environment_variables=_DB_ENV,
     )


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
[CI:TOXENVS] mariadb