### PR TITLE
Skip test_url for AI containers

### DIFF
--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -479,7 +479,6 @@ def test_general_labels(
             assert "BCI" in labels[f"{prefix}.title"]
 
 
-@SKIP_IF_AI_MARK
 @pytest.mark.parametrize(
     "container,container_name,container_type",
     IMAGES_AND_NAMES,
@@ -516,8 +515,12 @@ def test_url(
             ImageType.SAC_LANGUAGE_STACK,
             ImageType.SAC_APPLICATION,
         ):
+            container_mapping: dict[str, str] = {
+                "lmcache-lmstack-router": "vllm",
+                "lmcache-vllm-openai": "vllm",
+            }
             expected_url = (
-                f"https://apps.rancher.io/applications/{container_name}",
+                f"https://apps.rancher.io/applications/{container_mapping.get(container_name, container_name)}",
                 f"https://apps.rancher.io/applications/{container_name.rpartition('-')[0]}",
             )
         elif container_type == ImageType.OS_LTSS:


### PR DESCRIPTION
Skip `tests/test_metadata.py::test_url` for AI containers. This test fails for the vLLM containers (`vllm-openai`, `lmcache-vllm-openai`, `lmcache-lmstack-router`), as the application URL doesn't match the container name:

```
FAILED tests/test_metadata.py::test_url[container89-lmcache-lmstack-router-application] - AssertionError: expected LABEL com.suse.application.lmcache-lmstack-router.url = ('https://apps.rancher.io/applications/lmcache-lmstack-router', 'https://apps.rancher.io/applications/lmcache-lmstack') but is https://apps.rancher.io/applications/vllm
assert 'https://apps.rancher.io/applications/vllm' in ('https://apps.rancher.io/applications/lmcache-lmstack-router', 'https://apps.rancher.io/applications/lmcache-lmstack')
```

[CI:TOXENVS] ai
