### PR TITLE
Added test to run nginx as a non-root user

### DIFF
--- a/tests/files/nginx/nginx.conf
+++ b/tests/files/nginx/nginx.conf
@@ -1,0 +1,142 @@
+
+#user  nginx;
+worker_processes  1;
+
+# load_module lib64/nginx/modules/ngx_http_fancyindex_module.so;
+# load_module lib64/nginx/modules/ngx_http_headers_more_filter_module.so;
+# load_module lib64/nginx/modules/ngx_http_image_filter_module.so;
+# load_module lib64/nginx/modules/ngx_http_perl_module.so;
+# load_module lib64/nginx/modules/ngx_http_xslt_filter_module.so;
+# load_module lib64/nginx/modules/ngx_mail_module.so;
+# load_module lib64/nginx/modules/ngx_rtmp_module.so;
+# load_module lib64/nginx/modules/ngx_stream_module.so;
+
+#error_log  /var/log/nginx/error.log;
+#error_log  /var/log/nginx/error.log  notice;
+#error_log  /var/log/nginx/error.log  info;
+
+pid        /tmp/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+    use epoll;
+}
+
+
+
+http {
+    include       mime.types;
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path       /tmp/proxy_temp_path;
+    fastcgi_temp_path     /tmp/fastcgi_temp;
+    uwsgi_temp_path       /tmp/uwsgi_temp;
+    scgi_temp_path        /tmp/scgi_temp;
+    default_type  application/octet-stream;
+
+    #log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+    #                  '$status $body_bytes_sent "$http_referer" '
+    #                  '"$http_user_agent" "$http_x_forwarded_for"';
+
+    #access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    #keepalive_timeout  0;
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include conf.d/*.conf;
+
+    server {
+        listen       8080;
+        server_name  localhost;
+
+        #charset koi8-r;
+
+        #access_log  /var/log/nginx/host.access.log  main;
+
+        location / {
+            root   /srv/www/htdocs/;
+            index  index.html index.htm;
+        }
+
+        #error_page  404              /404.html;
+
+        # redirect server error pages to the static page /50x.html
+        #
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   /srv/www/htdocs/;
+        }
+
+        # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+        #
+        #location ~ \.php$ {
+        #    proxy_pass   http://127.0.0.1;
+        #}
+
+        # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+        #
+        #location ~ \.php$ {
+        #    root           /srv/www/htdocs/;
+        #    fastcgi_pass   127.0.0.1:9000;
+        #    fastcgi_index  index.php;
+        #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+        #    include        fastcgi_params;
+        #}
+
+        # deny access to .htaccess files, if Apache's document root
+        # concurs with nginx's one
+        #
+        #location ~ /\.ht {
+        #    deny  all;
+        #}
+    }
+
+
+    # another virtual host using mix of IP-, name-, and port-based configuration
+    #
+    #server {
+    #    listen       8000;
+    #    listen       somename:8080;
+    #    server_name  somename  alias  another.alias;
+
+    #    location / {
+    #        root   /srv/www/htdocs/;
+    #        index  index.html index.htm;
+    #    }
+    #}
+
+
+    # HTTPS server
+    #
+    #server {
+    #    listen       443 ssl;
+    #    server_name  localhost;
+
+    #    ssl_certificate      cert.pem;
+    #    ssl_certificate_key  cert.key;
+
+    #    Allow TLS version 1.2 only, which is a recommended default these days
+    #    by international information security standards.
+    #    ssl_protocols        TLSv1.2;
+
+    #    ssl_session_cache    shared:SSL:1m;
+    #    ssl_session_timeout  5m;
+
+    #    ssl_ciphers  HIGH:!aNULL:!MD5;
+    #    ssl_prefer_server_ciphers  on;
+
+    #    location / {
+    #        root   /srv/www/htdocs/;
+    #        index  index.html index.htm;
+    #    }
+    #}
+
+    include vhosts.d/*.conf;
+
+}
+

--- a/tests/test_nginx.py
+++ b/tests/test_nginx.py
@@ -1,6 +1,16 @@
 """This module contains the tests for the nginx container, the image with nginx pre-installed."""
 
+from pathlib import Path
+from typing import List
+
+import pytest
 import requests
+from _pytest.mark import ParameterSet
+from pytest_container.container import BindMount
+from pytest_container.container import ContainerData
+from pytest_container.container import DerivedContainer
+from pytest_container.container import PortForwarding
+from pytest_container.container import container_and_marks_from_pytest_param
 from tenacity import retry
 from tenacity import stop_after_attempt
 from tenacity import wait_exponential
@@ -13,6 +23,60 @@ CONTAINER_IMAGES = (NGINX_CONTAINER,)
 def test_nginx_welcome_page(auto_container):
     """test that the default welcome page is served by the container."""
     host_port = auto_container.forwarded_ports[0].host_port
+
+    # Retry 5 times with exponential backoff delay
+    @retry(
+        wait=wait_exponential(multiplier=1, min=4, max=10),
+        stop=stop_after_attempt(5),
+    )
+    def check_nginx_response():
+        resp = requests.get(f"http://localhost:{host_port}/", timeout=30)
+        resp.raise_for_status()
+        assert "Welcome to nginx" in resp.text
+
+    check_nginx_response()
+
+
+_NGINX_CONFIG_FILE_PATH = (
+    Path(__file__).parent / "files" / "nginx" / "nginx.conf"
+)
+
+
+def _generate_non_root_test_matrix() -> List[ParameterSet]:
+    params = []
+    for ng_cont_param in CONTAINER_IMAGES:
+        ng_cont = container_and_marks_from_pytest_param(ng_cont_param)[0]
+        marks = ng_cont_param.marks
+        params.append(
+            pytest.param(
+                DerivedContainer(
+                    base=ng_cont,
+                    forwarded_ports=[PortForwarding(container_port=8080)],
+                    extra_launch_args=(["--user", "nginx"]),
+                    volume_mounts=[
+                        BindMount(
+                            container_path="/etc/nginx/nginx.conf",
+                            host_path=_NGINX_CONFIG_FILE_PATH,
+                        ),
+                    ],
+                ),
+                marks=marks,
+            )
+        )
+
+    return params
+
+
+@pytest.mark.parametrize(
+    "container_per_test",
+    _generate_non_root_test_matrix(),
+    indirect=["container_per_test"],
+)
+def test_nginx_welcome_page_as_non_root_user(
+    container_per_test: ContainerData,
+):
+    """test that the default welcome page is served by the container."""
+    host_port = container_per_test.forwarded_ports[0].host_port
 
     # Retry 5 times with exponential backoff delay
     @retry(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
 [CI:TOXENVS] nginx