### PR TITLE
Skip downgrade-tests on SLES 16.1 unconditionally

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -51,7 +51,6 @@ from bci_tester.data import OS_VERSION_ID
 from bci_tester.data import PCP_CONTAINERS
 from bci_tester.data import RELEASED_LTSS_VERSIONS
 from bci_tester.data import RELEASED_SLE_VERSIONS
-from bci_tester.data import TARGET
 from bci_tester.data import ZYPP_CREDENTIALS_DIR
 from bci_tester.util import get_repos_from_connection
 
@@ -284,7 +283,7 @@ for param in CONTAINERS_WITH_ZYPPER_AS_ROOT:
 
 
 @pytest.mark.skipif(
-    OS_VERSION.startswith("16.1") and TARGET in ("dso", "obs"),
+    OS_VERSION.startswith("16.1"),
     reason="16.1 is not having regular bci-repo publishes",
 )
 @pytest.mark.skipif(


### PR DESCRIPTION
There are no SLES 16.1 repos available until public beta, so the downgrade tests needs to be skipped until then.

Related failure: https://openqa.suse.de/tests/21598666#step/_root_BCI-tests_all_/14