### PR TITLE
Add handling for SPR's new repo structure

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -2,7 +2,6 @@
 
 import enum
 import os
-import re
 from datetime import timedelta
 from itertools import chain
 from itertools import product
@@ -31,6 +30,10 @@ from _pytest.mark.structures import MarkDecorator
 from _pytest.mark.structures import ParameterSet
 
 from bci_tester.runtime_choice import DOCKER_SELECTED
+from bci_tester.util import get_repository_name
+from bci_tester.util import get_spr_namespace
+from bci_tester.util import get_spr_version
+from bci_tester.util import is_spr
 
 #: The operating system version as present in /etc/os-release & various other
 #: places
@@ -170,34 +173,6 @@ else:
     )
 
 
-def _get_spr_version(os_version: str = OS_VERSION) -> Optional[str]:
-    match = re.search(
-        r"(\d+\.\d+)-spr(\d+\.\d+){0,1}", os_version
-    )  # 15.6-spr, 15.7-spr, 15.7-spr1.2, etc.
-    if match is None:
-        return None
-
-    if match[2]:
-        return match[2]
-
-    if match[1] == "15.6":
-        return "1.0"
-
-    if match[1] == "15.7":
-        return "1.1"
-
-    return None
-
-
-def _get_spr_namespace(os_version: str = OS_VERSION) -> str:
-    spr_ver = _get_spr_version(os_version)
-    return "" if spr_ver in (None, "1.0", "1.1") else f"/{spr_ver}"
-
-
-def _is_spr(os_version: str = OS_VERSION) -> bool:
-    return _get_spr_version(os_version) is not None
-
-
 #: value of the environment variable ``TARGET`` which defines whether we are
 #: taking the images from OBS, IBS or the ``CR:ToTest`` project on IBS
 TARGET = os.getenv("TARGET", "obs")
@@ -247,11 +222,11 @@ else:
         ibs_cr_project = (
             f"registry.suse.de/suse/slfo/products/bci/{DISTNAME}/test"
         )
-    elif _is_spr():
-        ibs_project = f"registry.suse.de/suse/{DISTNAME}/update/products/privateregistry{_get_spr_namespace()}"
+    elif is_spr():
+        ibs_project = f"registry.suse.de/suse/{DISTNAME}/update/products/privateregistry{get_spr_namespace()}"
         ibs_cr_project = f"{ibs_project}/totest"
         obs_project = (
-            f"registry.suse.de/devel/scc/privateregistry/{_get_spr_version()}"
+            f"registry.suse.de/devel/scc/privateregistry/{get_spr_version()}"
         )
 
     BASEURL = {
@@ -326,22 +301,6 @@ else:
 assert BCI_DEVEL_REPO, "BCI_DEVEL_REPO must be set at this point"
 
 _IMAGE_TYPE_T = Literal["dockerfile", "kiwi"]
-
-
-def _get_repository_name(image_type: _IMAGE_TYPE_T) -> str:
-    if TARGET in ("dso", "ibs-released"):
-        return ""
-    if TARGET == "ibs-cr":
-        if OS_VERSION == "16.0-pc2025":
-            return "containers_registry_16.0/"
-        return "containerfile/" if OS_VERSION.startswith("16") else "images/"
-    if TARGET in ("factory-totest", "factory-arm-totest"):
-        return "containers/"
-    if image_type == "dockerfile":
-        return "containerfile/"
-    if image_type == "kiwi":
-        return "containerkiwi/" if OS_VERSION.startswith("16") else "images/"
-    raise AssertionError(f"invalid image_type: {image_type}")
 
 
 @enum.unique
@@ -471,13 +430,11 @@ def create_BCI(
             raise ValueError("Missing CONTAINER_URL for TARGET manual")
     elif OS_VERSION == "tumbleweed":
         if bci_type in (ImageType.APPLICATION, ImageType.SAC_APPLICATION):
-            baseurl = (
-                f"{BASEURL}/{_get_repository_name(image_type)}{build_tag}"
-            )
+            baseurl = f"{BASEURL}/{get_repository_name(image_type)}{build_tag}"
         else:
-            baseurl = f"{BASEURL}/{_get_repository_name(image_type)}opensuse/{build_tag}"
+            baseurl = f"{BASEURL}/{get_repository_name(image_type)}opensuse/{build_tag}"
     else:
-        baseurl = f"{BASEURL}/{_get_repository_name(image_type)}{build_tag}"
+        baseurl = f"{BASEURL}/{get_repository_name(image_type)}{build_tag}"
 
     if bci_type == ImageType.OS_LTSS:
         containerfile = ""
@@ -1350,7 +1307,7 @@ KUBEVIRT_CDI_CONTAINERS = [
 
 SPR_CONTAINERS = [
     create_BCI(
-        build_tag=f"private-registry{_get_spr_namespace(os_version)}/harbor-{service}:latest",
+        build_tag=f"private-registry{get_spr_namespace(os_version)}/harbor-{service}:latest",
         bci_type=ImageType.APPLICATION,
         available_versions=[os_version],
         custom_entry_point="/bin/sh" if service != "db" else "",

--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -2,6 +2,7 @@
 
 import enum
 import os
+import re
 from datetime import timedelta
 from itertools import chain
 from itertools import product
@@ -52,6 +53,7 @@ ALLOWED_NONBASE_OS_VERSIONS = (
     "15.6-spr",
     "15.7",
     "15.7-spr",
+    "15.7-spr1.2",
     "15.7-third-party",
     "16.0",
     "16.0-pc2025",
@@ -64,6 +66,7 @@ ALLOWED_NONBASE_OS_VERSIONS = (
 ALLOWED_BCI_REPO_OS_VERSIONS = (
     "15.7",
     "15.7-spr",
+    "15.7-spr1.2",
     "16.0",
     "16.1",
     "tumbleweed",
@@ -90,6 +93,7 @@ RELEASED_SLE_VERSIONS = (
     "15.6-spr",
     "15.7",
     "15.7-spr",
+    "15.7-spr1.2",
     "15.7-third-party",
     "16.0",
     "16.0-third-party",
@@ -166,6 +170,34 @@ else:
     )
 
 
+def _get_spr_version(os_version: str = OS_VERSION) -> Optional[str]:
+    match = re.search(
+        r"(\d+\.\d+)-spr(\d+\.\d+){0,1}", os_version
+    )  # 15.6-spr, 15.7-spr, 15.7-spr1.2, etc.
+    if match is None:
+        return None
+
+    if match[2]:
+        return match[2]
+
+    if match[1] == "15.6":
+        return "1.0"
+
+    if match[1] == "15.7":
+        return "1.1"
+
+    return None
+
+
+def _get_spr_namespace(os_version: str = OS_VERSION) -> str:
+    spr_ver = _get_spr_version(os_version)
+    return "" if spr_ver in (None, "1.0", "1.1") else f"/{spr_ver}"
+
+
+def _is_spr(os_version: str = OS_VERSION) -> bool:
+    return _get_spr_version(os_version) is not None
+
+
 #: value of the environment variable ``TARGET`` which defines whether we are
 #: taking the images from OBS, IBS or the ``CR:ToTest`` project on IBS
 TARGET = os.getenv("TARGET", "obs")
@@ -215,9 +247,12 @@ else:
         ibs_cr_project = (
             f"registry.suse.de/suse/slfo/products/bci/{DISTNAME}/test"
         )
-    elif OS_VERSION in ("15.6-spr", "15.7-spr"):
-        ibs_cr_project = f"registry.suse.de/suse/{DISTNAME}/update/products/privateregistry/totest"
-        obs_project = "registry.suse.de/devel/scc/privateregistry"
+    elif _is_spr():
+        ibs_project = f"registry.suse.de/suse/{DISTNAME}/update/products/privateregistry{_get_spr_namespace()}"
+        ibs_cr_project = f"{ibs_project}/totest"
+        obs_project = (
+            f"registry.suse.de/devel/scc/privateregistry/{_get_spr_version()}"
+        )
 
     BASEURL = {
         "obs": obs_project,
@@ -1312,9 +1347,10 @@ KUBEVIRT_CDI_CONTAINERS = [
     )
 ]
 
+
 SPR_CONTAINERS = [
     create_BCI(
-        build_tag=f"private-registry/harbor-{service}:latest",
+        build_tag=f"private-registry{_get_spr_namespace(os_version)}/harbor-{service}:latest",
         bci_type=ImageType.APPLICATION,
         available_versions=[os_version],
         custom_entry_point="/bin/sh" if service != "db" else "",
@@ -1324,7 +1360,11 @@ SPR_CONTAINERS = [
     )
     for os_version, service in chain(
         product(
-            ("15.6-spr", "15.7-spr"),
+            (
+                "15.6-spr",
+                "15.7-spr",
+                "15.7-spr1.2",
+            ),
             (
                 "core",
                 "exporter",

--- a/bci_tester/util.py
+++ b/bci_tester/util.py
@@ -1,9 +1,12 @@
 """This module contains general purpose utility functions."""
 
+import os
+import re
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from typing import Dict
 from typing import List
+from typing import Optional
 
 from pytest_container import Version
 
@@ -69,3 +72,55 @@ def get_repos_from_zypper_xmlout(zypper_xmlout: str) -> List[Repository]:
 def get_repos_from_connection(con) -> List[Repository]:
     """Gets the list of repositories given a testinfra connection."""
     return get_repos_from_zypper_xmlout(con.check_output("zypper -x repos"))
+
+
+def get_spr_version(os_version: Optional[str] = None) -> Optional[str]:
+    """Return the SPR version string for the given OS_VERSION, or None if not an SPR variant."""
+    if os_version is None:
+        os_version = os.getenv("OS_VERSION", "15.7")
+    match = re.search(
+        r"(\d+\.\d+)-spr(\d+\.\d+){0,1}", os_version
+    )  # 15.6-spr, 15.7-spr, 15.7-spr1.2, etc.
+    if match is None:
+        return None
+
+    if match[2]:
+        return match[2]
+
+    if match[1] == "15.6":
+        return "1.0"
+
+    if match[1] == "15.7":
+        return "1.1"
+
+    return None
+
+
+def get_spr_namespace(os_version: Optional[str] = None) -> str:
+    """Return the registry namespace suffix for SPR (e.g. '/1.2') or empty string."""
+    spr_ver = get_spr_version(os_version)
+    return "" if spr_ver in (None, "1.0", "1.1") else f"/{spr_ver}"
+
+
+def is_spr(os_version: Optional[str] = None) -> bool:
+    """Return True if the given OS_VERSION is an SPR variant."""
+    return get_spr_version(os_version) is not None
+
+
+def get_repository_name(image_type: str) -> str:
+    """Return the registry path segment for the given image type and current TARGET/OS_VERSION."""
+    target = os.getenv("TARGET", "obs")
+    os_version = os.getenv("OS_VERSION", "15.7")
+    if target in ("dso", "ibs-released"):
+        return ""
+    if target == "ibs-cr":
+        if os_version == "16.0-pc2025":
+            return "containers_registry_16.0/"
+        return "containerfile/" if os_version.startswith("16") else "images/"
+    if target in ("factory-totest", "factory-arm-totest"):
+        return "containers/"
+    if image_type == "dockerfile":
+        return "containerfile/"
+    if image_type == "kiwi":
+        return "containerkiwi/" if os_version.startswith("16") else "images/"
+    raise AssertionError(f"invalid image_type: {image_type}")

--- a/bci_tester/util.py
+++ b/bci_tester/util.py
@@ -8,6 +8,11 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
 from pytest_container import Version
 
 
@@ -107,7 +112,7 @@ def is_spr(os_version: Optional[str] = None) -> bool:
     return get_spr_version(os_version) is not None
 
 
-def get_repository_name(image_type: str) -> str:
+def get_repository_name(image_type: Literal["dockerfile", "kiwi"]) -> str:
     """Return the registry path segment for the given image type and current TARGET/OS_VERSION."""
     target = os.getenv("TARGET", "obs")
     os_version = os.getenv("OS_VERSION", "15.7")

--- a/pre-commit-full.sh
+++ b/pre-commit-full.sh
@@ -2,7 +2,7 @@
 
 tox -e format -- --check
 
-for OS_VERSION in "15.4" "15.5" "15.6" "15.6-spr" "15.7" "15.7-spr" "16.0" "16.1" "tumbleweed"; do
+for OS_VERSION in "15.4" "15.5" "15.6" "15.6-spr" "15.7" "15.7-spr" "15.7-spr1.2" "16.0" "16.1" "tumbleweed"; do
     export OS_VERSION
     tox -e check_marks
 done

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -53,8 +53,8 @@ from bci_tester.data import RELEASED_LTSS_VERSIONS
 from bci_tester.data import RELEASED_SLE_VERSIONS
 from bci_tester.data import TARGET
 from bci_tester.data import ZYPP_CREDENTIALS_DIR
-from bci_tester.data import _is_spr
 from bci_tester.util import get_repos_from_connection
+from bci_tester.util import is_spr
 
 CONTAINER_IMAGES = ALL_CONTAINERS
 
@@ -518,7 +518,7 @@ def test_systemd_not_installed_in_all_containers_except_init(container):
 
 
 @pytest.mark.skipif(
-    OS_VERSION in ("15.4", "15.5") or _is_spr(),
+    OS_VERSION in ("15.4", "15.5") or is_spr(),
     reason="doesn't have the fixes for blkid/udev",
 )
 @pytest.mark.parametrize(

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -53,6 +53,7 @@ from bci_tester.data import RELEASED_LTSS_VERSIONS
 from bci_tester.data import RELEASED_SLE_VERSIONS
 from bci_tester.data import TARGET
 from bci_tester.data import ZYPP_CREDENTIALS_DIR
+from bci_tester.data import _is_spr
 from bci_tester.util import get_repos_from_connection
 
 CONTAINER_IMAGES = ALL_CONTAINERS
@@ -517,7 +518,7 @@ def test_systemd_not_installed_in_all_containers_except_init(container):
 
 
 @pytest.mark.skipif(
-    OS_VERSION in ("15.4", "15.5", "15.6-spr", "15.7-spr"),
+    OS_VERSION in ("15.4", "15.5") or _is_spr(),
     reason="doesn't have the fixes for blkid/udev",
 )
 @pytest.mark.parametrize(

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -105,6 +105,9 @@ from bci_tester.data import TARGET
 from bci_tester.data import TOMCAT_CONTAINERS
 from bci_tester.data import VALKEY_CONTAINERS
 from bci_tester.data import ImageType
+from bci_tester.data import _get_spr_namespace
+from bci_tester.data import _get_spr_version
+from bci_tester.data import _is_spr
 from bci_tester.runtime_choice import PODMAN_SELECTED
 
 #: The official vendor name
@@ -437,7 +440,7 @@ def test_general_labels(
                     or "based on the SLE LTSS Base Container Image"
                     in labels[f"{prefix}.description"]
                 )
-            elif OS_VERSION in ("15.7-spr",):
+            elif _is_spr():
                 assert (
                     "for SUSE Private Registry"
                     in labels[f"{prefix}.description"]
@@ -623,10 +626,6 @@ def test_support_end_in_future(
 
 
 @pytest.mark.skipif(
-    OS_VERSION == "15.7-spr",
-    reason="SPR publishes out of the devel project",
-)
-@pytest.mark.skipif(
     TARGET == "custom",
     reason="disturl can be anything if TARGET=custom",
 )
@@ -669,8 +668,11 @@ def test_disturl(
         )
     elif OS_VERSION == "15.6-ai" and TARGET in ("ibs", "obs"):
         assert "obs://build.suse.de/Devel:AI" in disturl
-    elif OS_VERSION == "15.7-spr" and TARGET in ("ibs", "obs"):
-        assert "obs://build.suse.de/Devel:SCC:PrivateRegistry:1.1" in disturl
+    elif _is_spr() and TARGET in ("obs",):
+        assert (
+            f"obs://build.suse.de/Devel:SCC:PrivateRegistry:{_get_spr_version()}"
+            in disturl
+        )
     elif OS_VERSION == "15.7-third-party" and TARGET in ("ibs", "ibs-cr"):
         assert (
             "obs://build.suse.de/Product:SUSE-Containers-ThirdParty:SLE-15-SP7"
@@ -851,8 +853,10 @@ def test_reference(
             assert reference.startswith("registry.opensuse.org/opensuse/")
         else:
             assert reference.startswith("registry.opensuse.org/opensuse/bci/")
-    elif OS_VERSION in ("15.7-spr",):
-        assert reference.startswith("registry.suse.com/private-registry/")
+    elif _is_spr():
+        assert reference.startswith(
+            f"registry.suse.com/private-registry{_get_spr_namespace()}/"
+        )
     else:
         if container_type in (
             ImageType.SAC_LANGUAGE_STACK,

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -105,10 +105,10 @@ from bci_tester.data import TARGET
 from bci_tester.data import TOMCAT_CONTAINERS
 from bci_tester.data import VALKEY_CONTAINERS
 from bci_tester.data import ImageType
-from bci_tester.data import _get_spr_namespace
-from bci_tester.data import _get_spr_version
-from bci_tester.data import _is_spr
 from bci_tester.runtime_choice import PODMAN_SELECTED
+from bci_tester.util import get_spr_namespace
+from bci_tester.util import get_spr_version
+from bci_tester.util import is_spr
 
 #: The official vendor name
 VENDOR = "openSUSE Project" if OS_VERSION == "tumbleweed" else "SUSE LLC"
@@ -440,7 +440,7 @@ def test_general_labels(
                     or "based on the SLE LTSS Base Container Image"
                     in labels[f"{prefix}.description"]
                 )
-            elif _is_spr():
+            elif is_spr():
                 assert (
                     "for SUSE Private Registry"
                     in labels[f"{prefix}.description"]
@@ -668,9 +668,9 @@ def test_disturl(
         )
     elif OS_VERSION == "15.6-ai" and TARGET in ("ibs", "obs"):
         assert "obs://build.suse.de/Devel:AI" in disturl
-    elif _is_spr() and TARGET in ("obs",):
+    elif is_spr() and TARGET in ("obs",):
         assert (
-            f"obs://build.suse.de/Devel:SCC:PrivateRegistry:{_get_spr_version()}"
+            f"obs://build.suse.de/Devel:SCC:PrivateRegistry:{get_spr_version()}"
             in disturl
         )
     elif OS_VERSION == "15.7-third-party" and TARGET in ("ibs", "ibs-cr"):
@@ -853,9 +853,9 @@ def test_reference(
             assert reference.startswith("registry.opensuse.org/opensuse/")
         else:
             assert reference.startswith("registry.opensuse.org/opensuse/bci/")
-    elif _is_spr():
+    elif is_spr():
         assert reference.startswith(
-            f"registry.suse.com/private-registry{_get_spr_namespace()}/"
+            f"registry.suse.com/private-registry{get_spr_namespace()}/"
         )
     else:
         if container_type in (

--- a/tests/test_spr.py
+++ b/tests/test_spr.py
@@ -21,6 +21,8 @@ from pytest_container.pod import PodData
 from bci_tester.data import BASEURL
 from bci_tester.data import OS_VERSION
 from bci_tester.data import _get_repository_name
+from bci_tester.data import _get_spr_namespace
+from bci_tester.data import _is_spr
 
 SPR_CONFIG_DIR = Path(__file__).parent.parent / "tests" / "files" / "spr"
 
@@ -190,7 +192,7 @@ for img, conf in SPR_CONFIG.items():
 
     url = conf.get(
         "url",
-        f"{BASEURL}/{_get_repository_name('dockerfile')}private-registry/harbor-{img}:latest",
+        f"{BASEURL}/{_get_repository_name('dockerfile')}private-registry{_get_spr_namespace()}/harbor-{img}:latest",
     )
 
     launch_args = [f"--name={conf.get('name', img)}"]
@@ -217,11 +219,7 @@ HARBOR_POD = Pod(
 
 
 @pytest.mark.skipif(
-    OS_VERSION
-    not in (
-        "15.6-spr",
-        "15.7-spr",
-    ),
+    not _is_spr(),
     reason="Harbor is only tested for SUSE Private Registry",
 )
 @pytest.mark.parametrize(

--- a/tests/test_spr.py
+++ b/tests/test_spr.py
@@ -20,9 +20,9 @@ from pytest_container.pod import PodData
 
 from bci_tester.data import BASEURL
 from bci_tester.data import OS_VERSION
-from bci_tester.data import _get_repository_name
-from bci_tester.data import _get_spr_namespace
-from bci_tester.data import _is_spr
+from bci_tester.util import get_repository_name
+from bci_tester.util import get_spr_namespace
+from bci_tester.util import is_spr
 
 SPR_CONFIG_DIR = Path(__file__).parent.parent / "tests" / "files" / "spr"
 
@@ -192,7 +192,7 @@ for img, conf in SPR_CONFIG.items():
 
     url = conf.get(
         "url",
-        f"{BASEURL}/{_get_repository_name('dockerfile')}private-registry{_get_spr_namespace()}/harbor-{img}:latest",
+        f"{BASEURL}/{get_repository_name('dockerfile')}private-registry{get_spr_namespace()}/harbor-{img}:latest",
     )
 
     launch_args = [f"--name={conf.get('name', img)}"]
@@ -219,7 +219,7 @@ HARBOR_POD = Pod(
 
 
 @pytest.mark.skipif(
-    not _is_spr(),
+    not is_spr(),
     reason="Harbor is only tested for SUSE Private Registry",
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
[CI:TOXENVS] spr

We will release SPR 1.2 on 2026-04-28

Starting with 1.2 we will publish each version to a dedicated namespace in r.s.c., like

- `registry.suse.com/private-registry/1.2/`
- `registry.suse.com/private-registry/1.3/`
- etc.

This PR addresses this in setting the right paths for each TARGET.