### PR TITLE
Add Python 3.14 containers to testing

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -710,7 +710,7 @@ PYTHON_BASE_CONTAINERS = [
         build_tag=f"{BCI_CONTAINER_PREFIX}/python:{ver}-base",
         available_versions=versions,
     )
-    for ver, versions in (("3.13", ["16.0"]),)
+    for ver, versions in (("3.13", ["16.0"]), ("3.14", ["tumbleweed", "16.1"]))
 ]
 
 PYTHON_WITH_PIPX_CONTAINERS = PYTHON_BASE_CONTAINERS + [
@@ -726,7 +726,7 @@ PYTHON_MICRO_CONTAINERS = [
         build_tag=f"{BCI_CONTAINER_PREFIX}/python:{ver}-micro",
         available_versions=versions,
     )
-    for ver, versions in (("3.13", ["16.0"]),)
+    for ver, versions in (("3.13", ["16.0"]), ("3.14", ["tumbleweed", "16.1"]))
 ]
 
 PYTHON_CONTAINERS = PYTHON_WITH_PIPX_CONTAINERS + [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,6 +207,8 @@ markers = [
     'python_3.13',
     'python_3.13-base',
     'python_3.13-micro',
+    'python_3.14-base',
+    'python_3.14-micro',
     'python_3.6',
     'registry_2.8',
     'registry_3.0',


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
