### PR TITLE
Update gcc hello version

### DIFF
--- a/tests/test_gcc.py
+++ b/tests/test_gcc.py
@@ -9,11 +9,11 @@ from bci_tester.data import GCC_CONTAINERS
 
 CONTAINER_IMAGES = GCC_CONTAINERS
 
-_HELLO_VERSION = "2.12.2"
+_HELLO_VERSION = "2.12.3"
 
 CONTAINERFILE_HELLO = f"""
 WORKDIR /src
-RUN curl -sLO https://api.opensuse.org/public/source/openSUSE:Factory/hello/hello-{_HELLO_VERSION}.tar.gz?rev=91eb2953d334a8b971c512dccb0c6df3 && \\
+RUN curl -sLO https://api.opensuse.org/public/source/openSUSE:Factory/hello/hello-{_HELLO_VERSION}.tar.gz && \\
     tar --no-same-permissions --no-same-owner -xf hello-{_HELLO_VERSION}.tar.gz && \\
     cd hello-{_HELLO_VERSION} && \\
     ./configure && \\


### PR DESCRIPTION
Update the version of the gcc HELLO container to the recent version for the glibc update in Tumbleweed.

Fixes https://github.com/SUSE/BCI-tests/issues/1050

### Verification runs

* [Tumbleweed](https://duck-norris.qe.suse.de/tests/95)
* [SLES 15-SP7](https://duck-norris.qe.suse.de/tests/97#step/_root_BCI-tests_gcc_/2) (unrelated failure)