### PR TITLE
Skip rancher build on host systems that are too old

### DIFF
--- a/tests/test_go.py
+++ b/tests/test_go.py
@@ -151,6 +151,10 @@ def test_build_generics_cache(
     indirect=["host_git_clone"],
 )
 @pytest.mark.skipif(
+    "--build-arg" not in LOCALHOST.check_output("docker buildx build --help"),
+    reason="docker too old for Rancher build",
+)
+@pytest.mark.skipif(
     not DOCKER_SELECTED, reason="Rancher only works with docker"
 )
 @pytest.mark.skipif(


### PR DESCRIPTION
[CI:TOXENVS] go
