### PR TITLE
Move buildx check after Docker check

### DIFF
--- a/tests/test_go.py
+++ b/tests/test_go.py
@@ -151,11 +151,11 @@ def test_build_generics_cache(
     indirect=["host_git_clone"],
 )
 @pytest.mark.skipif(
-    "--build-arg" not in LOCALHOST.check_output("docker buildx build --help"),
-    reason="docker too old for Rancher build",
+    not DOCKER_SELECTED, reason="Rancher only works with docker"
 )
 @pytest.mark.skipif(
-    not DOCKER_SELECTED, reason="Rancher only works with docker"
+    "--build-arg" not in LOCALHOST.check_output("docker buildx build --help"),
+    reason="docker too old for Rancher build",
 )
 @pytest.mark.skipif(
     not OS_VERSION.startswith("15"),


### PR DESCRIPTION
If the runtime is not Docker, docker might not be installed.

[CI:TOXENVS] go,minimal
