### PR TITLE
More 16.1 containers

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -1063,7 +1063,7 @@ GCC_CONTAINERS = [
     for gcc_version, os_versions in (
         (13, ("tumbleweed",)),
         (14, ("15.7", "tumbleweed")),
-        (15, ("16.0", "tumbleweed")),
+        (15, ("16.0", "16.1", "tumbleweed")),
     )
 ]
 
@@ -1176,7 +1176,7 @@ VALKEY_CONTAINERS = [
         forwarded_ports=[PortForwarding(container_port=6379)],
     )
     for versions, tag in (
-        (("15.7", "16.0"), "8.0"),
+        (("15.7", "16.0", "16.1"), "8.0"),
         (("tumbleweed",), "latest"),
     )
 ]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
