### PR TITLE
Pin i18n version for 15.7

### DIFF
--- a/tests/test_ruby.py
+++ b/tests/test_ruby.py
@@ -48,7 +48,7 @@ def test_lang_set(auto_container):
         ("multi_json -v 1.15.0" if OS_VERSION in ("15.7",) else "multi_json"),
         "rack",
         "rake",
-        "i18n",
+        ("i18n -v 1.14.8" if OS_VERSION in ("15.7",) else "i18n"),
     ],
 )
 def test_install_gems(auto_container_per_test, gem):


### PR DESCRIPTION
Newer versions don't support Ruby 2.5.

CI:TOXENVS] ruby,minimal
