### PR TITLE
Adjust SPR 1.0 tests to the changes in 1.0.2

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -53,9 +53,9 @@ ALLOWED_BASE_OS_VERSIONS = (
 # Allowed os versions for Language and Application containers
 ALLOWED_NONBASE_OS_VERSIONS = (
     "15.6",
-    "15.6-spr",
     "15.7",
     "15.7-spr",
+    "15.7-spr1.0",
     "15.7-spr1.2",
     "15.7-third-party",
     "16.0",
@@ -69,6 +69,7 @@ ALLOWED_NONBASE_OS_VERSIONS = (
 ALLOWED_BCI_REPO_OS_VERSIONS = (
     "15.7",
     "15.7-spr",
+    "15.7-spr1.0",
     "15.7-spr1.2",
     "16.0",
     "16.1",
@@ -93,9 +94,9 @@ RELEASED_SLE_VERSIONS = (
     "15.4",
     "15.5",
     "15.6",
-    "15.6-spr",
     "15.7",
     "15.7-spr",
+    "15.7-spr1.0",
     "15.7-spr1.2",
     "15.7-third-party",
     "16.0",
@@ -1338,8 +1339,8 @@ SPR_CONTAINERS = [
     for os_version, service in chain(
         product(
             (
-                "15.6-spr",
                 "15.7-spr",
+                "15.7-spr1.0",
                 "15.7-spr1.2",
             ),
             (
@@ -1350,14 +1351,6 @@ SPR_CONTAINERS = [
                 "registry",
                 "registryctl",
                 "trivy-adapter",
-            ),
-        ),
-        product(
-            ("15.6-spr",),
-            (
-                "db",
-                "nginx",
-                "valkey",
             ),
         ),
     )

--- a/pre-commit-full.sh
+++ b/pre-commit-full.sh
@@ -2,7 +2,7 @@
 
 tox -e format -- --check
 
-for OS_VERSION in "15.4" "15.5" "15.6" "15.6-spr" "15.7" "15.7-spr" "15.7-spr1.2" "16.0" "16.1" "tumbleweed"; do
+for OS_VERSION in "15.4" "15.5" "15.6" "15.7" "15.7-spr" "15.7-spr1.0" "15.7-spr1.2" "16.0" "16.1" "tumbleweed"; do
     export OS_VERSION
     tox -e check_marks
 done

--- a/tests/test_spr.py
+++ b/tests/test_spr.py
@@ -19,7 +19,6 @@ from pytest_container.pod import Pod
 from pytest_container.pod import PodData
 
 from bci_tester.data import BASEURL
-from bci_tester.data import OS_VERSION
 from bci_tester.util import get_repository_name
 from bci_tester.util import get_spr_namespace
 from bci_tester.util import is_spr
@@ -176,19 +175,9 @@ SPR_CONFIG = {
 SPR_CONTAINERS_FOR_POD = []
 
 for img, conf in SPR_CONFIG.items():
-    # 15.7-spr means SPR 1.1.x (onwards) where we use BCI images for db, nginx and valkey.
+    # SPR 1.1.x (onwards) uses BCI images for db, nginx and valkey.
     # In that case SPR_CONFIG.url points to a suitable BCI image.
     #
-    # 15.6-spr means SPR 1.0.x where we built extra images for db, nginx, and valkey.
-    # In that case SPR_CONFIG.url is dropped so that the default url pointing to
-    # the private-registry images is used.
-    # For the SPR's postgres (db) image the volume containing the initial DB scheme is dropped
-    # because the image already includes it.
-
-    if OS_VERSION == "15.6-spr":
-        conf.pop("url", None)
-        if img == "db":
-            conf["volumes"].pop()
 
     url = conf.get(
         "url",

--- a/tests/test_spr.py
+++ b/tests/test_spr.py
@@ -175,9 +175,9 @@ SPR_CONFIG = {
 SPR_CONTAINERS_FOR_POD = []
 
 for img, conf in SPR_CONFIG.items():
-    # SPR 1.1.x (onwards) uses BCI images for db, nginx and valkey.
-    # In that case SPR_CONFIG.url points to a suitable BCI image.
-    #
+    # Some SPR services (db/nginx/valkey) use public BCI images; for those entries
+    # SPR_CONFIG provides an explicit `url`. All other services fall back to the
+    # private-registry images built as part of SPR.
 
     url = conf.get(
         "url",


### PR DESCRIPTION
[CI:TOXENVS] spr

To finally address some issues in SPR 1.0.1 we now switch to SP7 and the BCI images for postgres, nginx and valkey.

Adjusting tests to handle this new layout.

<!--
Thanks for sending a pull request!

In case you are changing only tests for a specific environment and don't need to
run all test environments, add the following line to your PR description on a
separate line! E.g.: [CI:TOXENVS] postgres,minimal

The following tox environments are always added:
all, repository, metadata, multistage

You can obtain the list of all available environments by running `tox -l`.
-->
