### PR TITLE
SUSE kmp is being used for open drivers

### DIFF
--- a/tests/test_nvidia.py
+++ b/tests/test_nvidia.py
@@ -51,7 +51,6 @@ def test_image_content(container_per_test: ContainerData):
         files += [
             "/opt/open/nvidia-drm.ko.zst",
             "/opt/open/nvidia-modeset.ko.zst",
-            "/opt/open/nvidia-peermem.ko.zst",
             "/opt/open/nvidia-uvm.ko.zst",
             "/opt/open/nvidia.ko.zst",
             "/opt/proprietary/nvidia-drm.ko.zst",


### PR DESCRIPTION
The driver `/opt/open/nvidia-peermem.ko.zst` is no longer present in the images.

- https://jira.suse.com/browse/PED-6160

