### PR TITLE
Do not test coreutils for cosign

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -251,7 +251,12 @@ def test_opensuse_product_flavor(container):
     [
         c
         for c in ALL_CONTAINERS
-        if c not in (BUSYBOX_CONTAINER, DISTRIBUTION_CONTAINER, NANO_CONTAINER)
+        if c
+        not in (
+            BUSYBOX_CONTAINER,
+            DISTRIBUTION_CONTAINER,
+            CONTAINERS_WITHOUT_SHELL,
+        )
     ],
     indirect=True,
 )


### PR DESCRIPTION
Cosign switched to nano, where the coreutils are not present.

[CI:TOXENVS] cosign