### PR TITLE
Revert systemd-coredump group ID change

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -851,7 +851,7 @@ _USERNAME_UID_GID_MAP: Dict[str, Tuple[Optional[int], Optional[int]]] = {
     "postgres": (None, 486),
     "pcp": (496, 484),
     "ldap": (498, 498),
-    "systemd-coredump": (497, 1000),
+    "systemd-coredump": (497, 100),
     "postfix": (51, 51),
     "keadhcp": (None, 486),
     "user": (1000, 1000),
@@ -890,6 +890,7 @@ def test_uids_stable(auto_container) -> None:
             expected_map["pcp"] = [496, 498]
             expected_map["wwwrun"] = [498, 498]
             expected_map["pesign"] = [499, 499]
+            expected_map["systemd-coredump"] = [497, 1000]
 
         # Handle the 'kiosk/xorg' special case
         if (


### PR DESCRIPTION
This reverts commit 6135ea167071109fd830fa8da8ff498efb750826.

See bsc#1262307 and bsc#1262307.

[CI:TOXENVS] all, minimal
