### PR TITLE
Remove SP7 from general run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,7 +119,6 @@ jobs:
       matrix:
         toxenv: ${{fromJson(needs.gentestmatrix.outputs.matrix)}}
         os_version:
-          - 15.7
           - "16.0"
           - "16.1"
           - "tumbleweed"
@@ -186,6 +185,64 @@ jobs:
             os_version: 15.6
           - toxenv: fips
             os_version: 15.6
+          - toxenv: all
+            os_version: 15.7
+          - toxenv: amd
+            os_version: 15.7
+          - toxenv: base
+            os_version: 15.7
+          - toxenv: busybox
+            os_version: 15.7
+          - toxenv: dotnet
+            os_version: 15.7
+          - toxenv: fips
+            os_version: 15.7
+          - toxenv: gcc
+            os_version: 15.7
+          - toxenv: go
+            os_version: 15.7
+          - toxenv: grafana
+            os_version: 15.7
+          - toxenv: init
+            os_version: 15.7
+          - toxenv: kernel_module
+            os_version: 15.7
+          - toxenv: kubectl
+            os_version: 15.7
+          - toxenv: mariadb
+            os_version: 15.7
+          - toxenv: metadata
+            os_version: 15.7
+          - toxenv: minimal
+            os_version: 15.7
+          - toxenv: multistage
+            os_version: 15.7
+          - toxenv: node
+            os_version: 15.7
+          - toxenv: nvidia
+            os_version: 15.7
+          - toxenv: openjdk
+            os_version: 15.7
+          - toxenv: openjdk_devel
+            os_version: 15.7
+          - toxenv: php
+            os_version: 15.7
+          - toxenv: postgres
+            os_version: 15.7
+          - toxenv: prometheus
+            os_version: 15.7
+          - toxenv: python
+            os_version: 15.7
+          - toxenv: repository
+            os_version: 15.7
+          - toxenv: ruby
+            os_version: 15.7
+          - toxenv: rust
+            os_version: 15.7
+          - toxenv: samba
+            os_version: 15.7
+          - toxenv: spack
+            os_version: 15.7
           - toxenv: amd
             os_version: 15.7-third-party
           - toxenv: nvidia

--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -862,7 +862,6 @@ CONTAINER_389DS_CONTAINERS = [
         forwarded_ports=[PortForwarding(container_port=3389)],
     )
     for ver, os_ver in (
-        ("2.7", ("15.7",)),
         ("3.0", ("16.0",)),
         ("3.1", ("16.1",)),
         ("latest", ("tumbleweed",)),
@@ -943,9 +942,7 @@ POSTGRESQL_CONTAINERS = [
 
 
 _distribution_version = "latest"
-if OS_VERSION in ("15.7",):
-    _distribution_version = "2.8"
-elif OS_VERSION in ("16.0", "16.1"):
+if OS_VERSION in ("16.0", "16.1"):
     _distribution_version = "3.1"
 
 DISTRIBUTION_CONTAINER = create_BCI(
@@ -956,16 +953,10 @@ DISTRIBUTION_CONTAINER = create_BCI(
 )
 
 _git_app_version = "latest"
-if OS_VERSION in (
-    "15.6",
-    "15.7",
-):
-    _git_app_version = "2.51"
-elif OS_VERSION in ("16.1",):
+if OS_VERSION in ("16.1",):
     _git_app_version = "2.53"
 elif OS_VERSION in ("16.0",):
     _git_app_version = "2.51"
-
 
 GIT_CONTAINER = create_BCI(
     build_tag=f"{APP_CONTAINER_PREFIX}/git:{_git_app_version}",
@@ -973,11 +964,10 @@ GIT_CONTAINER = create_BCI(
 )
 
 _helm_app_version = "latest"
-if OS_VERSION in ("15.7", "16.0"):
+if OS_VERSION in ("16.0"):
     _helm_app_version = "3"
 elif OS_VERSION in ("16.1",):
     _helm_app_version = "4"
-
 
 HELM_CONTAINER = create_BCI(
     build_tag=f"{APP_CONTAINER_PREFIX}/helm:{_helm_app_version}",
@@ -1003,7 +993,6 @@ NGINX_CONTAINERS = [
     )
     for nginx_ver, os_versions in (
         ("latest", ("tumbleweed",)),
-        ("1.21", ("15.7",)),
         ("1.27", ("16.0", "16.1")),
     )
 ]
@@ -1181,7 +1170,7 @@ VALKEY_CONTAINERS = [
         forwarded_ports=[PortForwarding(container_port=6379)],
     )
     for versions, tag in (
-        (("15.7", "16.0", "16.1"), "8.0"),
+        (("16.0", "16.1"), "8.0"),
         (("tumbleweed",), "latest"),
     )
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py36,py39,py310,py311,py312,py313,py314}-unit, all, base, cosign, fips, init, dotnet, python, ruby, node, go, openjdk, openjdk_devel, rust, php, busybox, 389ds, metadata, minimal, multistage, repository, doc, lint, check_marks, pcp, distribution, postgres, git, helm, nginx, kernel_module, mariadb, amd, nvidia, tomcat, spack, gcc, prometheus, grafana, kiwi, postfix, ai, stunnel, kubectl, kea, valkey, bind, samba, spr, nano
+envlist = {py36,py39,py310,py311,py312,py313,py314}-unit, all, base, cosign, fips, init, dotnet, python, ruby, node, go, openjdk, openjdk_devel, rust, php, busybox, 389ds, metadata, minimal, multistage, repository, doc, lint, check_marks, pcp, distribution, postgres, git, helm, nginx, kernel_module, mariadb, amd, nvidia, tomcat, spack, gcc, prometheus, grafana, kiwi, postfix, stunnel, kubectl, kea, valkey, bind, samba, spr, nano
 skip_missing_interpreters = True
 
 [common]


### PR DESCRIPTION
We are running a ton of test jobs for application containers that are not actually used anymore. remove them.
