### PR TITLE
python: add 3.13 to 16.1

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -724,7 +724,10 @@ PYTHON_BASE_CONTAINERS = [
         build_tag=f"{BCI_CONTAINER_PREFIX}/python:{ver}-base",
         available_versions=versions,
     )
-    for ver, versions in (("3.13", ["16.0"]), ("3.14", ["tumbleweed", "16.1"]))
+    for ver, versions in (
+        ("3.13", ["16.0", "16.1"]),
+        ("3.14", ["tumbleweed", "16.1"]),
+    )
 ]
 
 PYTHON_WITH_PIPX_CONTAINERS = PYTHON_BASE_CONTAINERS + [
@@ -740,7 +743,10 @@ PYTHON_MICRO_CONTAINERS = [
         build_tag=f"{BCI_CONTAINER_PREFIX}/python:{ver}-micro",
         available_versions=versions,
     )
-    for ver, versions in (("3.13", ["16.0"]), ("3.14", ["tumbleweed", "16.1"]))
+    for ver, versions in (
+        ("3.13", ["16.0", "16.1"]),
+        ("3.14", ["tumbleweed", "16.1"]),
+    )
 ]
 
 PYTHON_CONTAINERS = PYTHON_WITH_PIPX_CONTAINERS + [


### PR DESCRIPTION
Otherwise, the tests fail with no tests run.

[CI:TOXENVS] minimal, python
