### PR TITLE
ruby: force install rake on 16.1

### DIFF
--- a/tests/test_ruby.py
+++ b/tests/test_ruby.py
@@ -47,7 +47,10 @@ def test_lang_set(auto_container):
         "rspec",
         ("multi_json -v 1.15.0" if OS_VERSION in ("15.7",) else "multi_json"),
         "rack",
-        "rake",
+        (
+            # 16.1 uses alts and fails to override system binaries unless forced
+            "--force rake" if OS_VERSION in ("16.1",) else "rake"
+        ),
         ("i18n -v 1.14.8" if OS_VERSION in ("15.7",) else "i18n"),
     ],
 )
@@ -68,6 +71,7 @@ def test_install_gems(auto_container_per_test, gem):
     - rake
     - i18n
     """
+
     auto_container_per_test.connection.run_expect([0], f"gem install {gem}")
 
 


### PR DESCRIPTION
16.1 uses alts, and the installation refuses to override system binaries.

[CI:TOXENVS] minimal, ruby
