### PR TITLE
nginx: test root and rootless mode

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -995,7 +995,10 @@ NGINX_CONTAINERS = [
         build_tag=f"{APP_CONTAINER_PREFIX}/nginx:{nginx_ver}",
         bci_type=ImageType.APPLICATION,
         available_versions=os_versions,
-        forwarded_ports=[PortForwarding(container_port=80)],
+        forwarded_ports=[
+            PortForwarding(container_port=80),
+            PortForwarding(container_port=8080),
+        ],
     )
     for nginx_ver, os_versions in (
         ("latest", ("tumbleweed",)),

--- a/tests/test_nginx.py
+++ b/tests/test_nginx.py
@@ -1,6 +1,10 @@
 """This module contains the tests for the nginx container, the image with nginx pre-installed."""
 
+import pytest
 import requests
+from pytest_container import DerivedContainer
+from pytest_container.container import ContainerLauncher
+from pytest_container.runtime import OciRuntimeBase
 from tenacity import retry
 from tenacity import stop_after_attempt
 from tenacity import wait_exponential
@@ -9,19 +13,63 @@ from bci_tester.data import NGINX_CONTAINERS
 
 CONTAINER_IMAGES = NGINX_CONTAINERS
 
+USERS = [
+    "root",
+    "nginx",
+    0,
+    101,
+    499,
+    999,
+    1000,
+    1001,
+    10001,
+    65534,
+]
 
-def test_nginx_welcome_page(auto_container):
-    """test that the default welcome page is served by the container."""
-    host_port = auto_container.forwarded_ports[0].host_port
 
-    # Retry 5 times with exponential backoff delay
-    @retry(
-        wait=wait_exponential(multiplier=1, min=4, max=10),
-        stop=stop_after_attempt(5),
-    )
-    def check_nginx_response():
-        resp = requests.get(f"http://0.0.0.0:{host_port}/", timeout=30)
-        resp.raise_for_status()
-        assert "Welcome to nginx" in resp.text
+@retry(
+    wait=wait_exponential(multiplier=1, min=4, max=10),
+    stop=stop_after_attempt(5),
+)
+def check_nginx_response(host_port: int):
+    resp = requests.get(f"http://0.0.0.0:{host_port}/", timeout=30)
+    resp.raise_for_status()
+    assert "Welcome to nginx" in resp.text
 
-    check_nginx_response()
+
+@pytest.mark.parametrize("ctr_image", NGINX_CONTAINERS)
+@pytest.mark.parametrize("user", USERS)
+def test_nginx_welcome_page(
+    container_runtime: OciRuntimeBase,
+    pytestconfig: pytest.Config,
+    ctr_image: DerivedContainer,
+    user: tuple[int | str],
+):
+    """
+    Test that the default welcome page is served by the container
+    independent of which user is executing the container.
+
+    Ensure that the user inside the container matches the UID/username
+    defined in the container run command.
+    """
+
+    with ContainerLauncher.from_pytestconfig(
+        ctr_image, container_runtime, pytestconfig
+    ) as launcher:
+        launcher.extra_run_args.append(f"--user={user}")
+        launcher.launch_container()
+        con = launcher.container_data.connection
+
+        if isinstance(user, str):
+            assert con.run_expect([0], "id -u -n").stdout.strip() == user
+        else:
+            assert con.run_expect([0], "id -u").stdout.strip() == str(user)
+
+        if user in [0, "root"]:
+            # port 80 mapping
+            host_port = launcher.container_data.forwarded_ports[0].host_port
+        else:
+            # port 8080 mapping
+            host_port = launcher.container_data.forwarded_ports[1].host_port
+
+        check_nginx_response(host_port)


### PR DESCRIPTION
Add a test case to ensure that the container starts as expected in both root and rootless mode.

[CI:TOXENVS] minimal, nginx