### PR TITLE
fix(metadata): gpu containers do not have BCI tag

### DIFF
--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -513,7 +513,7 @@ def test_general_labels(
             )
             if container_name in ("nvidia-driver",):
                 assert "NVIDIA Driver" in labels[f"{prefix}.title"]
-            if container_name in ("amd-driver",):
+            elif container_name in ("amd-driver",):
                 assert "AMD GPU Driver" in labels[f"{prefix}.title"]
             elif container_name not in (
                 "dotnet.aspnet",


### PR DESCRIPTION
The new nvidia jobs fail with

```
AssertionError: assert 'BCI' in 'NVIDIA Driver for SUSE Linux Enterprise Server 15 SP7'
```

The title labels, has not changed, it seems like a test issue.

[CI:TOXENVS] metadata