### PR TITLE
Switch to testing RMT server 3

### DIFF
--- a/bci_tester/data.py
+++ b/bci_tester/data.py
@@ -1414,15 +1414,9 @@ SPR_CONTAINERS = [
 
 RMT_CONTAINERS = [
     create_BCI(
-        build_tag=f"{APP_CONTAINER_PREFIX}/rmt-server:2",
-        bci_type=ImageType.APPLICATION,
-        available_versions=("15.7",),
-        custom_entry_point="/bin/bash",
-    ),
-    create_BCI(
         build_tag=f"{APP_CONTAINER_PREFIX}/rmt-server:3",
         bci_type=ImageType.APPLICATION,
-        available_versions=_DEFAULT_NONBASE_SLFOPLUS_VERSIONS,
+        available_versions=_DEFAULT_NONBASE_SLE_VERSIONS,
         custom_entry_point="/bin/bash",
     ),
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,7 +232,6 @@ markers = [
     'registry_2.8',
     'registry_3.1',
     'registry_latest',
-    'rmt-server_2',
     'rmt-server_3',
     'ruby_2.5',
     'ruby_3.4',


### PR DESCRIPTION
[CI:TOXENVS] all

This also drops rmt-server from TW as it is no longer available there.